### PR TITLE
wrap language options in a default-opened treenode

### DIFF
--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -305,6 +305,8 @@ end
 
 function ReaSpeechUI:render_language_controls()
   if ImGui.TreeNode(ctx, 'Language Options', ImGui.TreeNodeFlags_DefaultOpen()) then
+    ImGui.Dummy(ctx, 0, 25)
+    ImGui.SameLine(ctx)
     if ImGui.BeginCombo(ctx, "language", self.LANGUAGES[self.language]) then
       local combo_items = self.LANGUAGE_CODES
       for _, combo_item in pairs(combo_items) do
@@ -328,7 +330,7 @@ end
 
 function ReaSpeechUI:render_advanced_controls()
   if ImGui.TreeNode(ctx, 'Advanced Options') then
-    ImGui.Dummy(ctx,0, 25)
+    ImGui.Dummy(ctx, 0, 25)
     ImGui.SameLine(ctx)
     ImGui.PushItemWidth(ctx, self.LARGE_ITEM_WIDTH)
     self:trap(function ()


### PR DESCRIPTION
I could be wrong, but it seemed like the layout looks slightly better using congruent treenodes. Took the opportunity to split out a couple of functions to represent each controls group.

<img width="960" alt="Screen Shot 2024-04-18 at 19 42 26" src="https://github.com/TeamAudio/reaspeech/assets/567097/95fbeeed-4174-4ea8-8823-1f87c0a23ea0">
