### PR TITLE
IntervalFunctions to use in the main UI `react`

### DIFF
--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -259,17 +259,17 @@ function ReaSpeechUI:interval_functions()
   end
 
   self._interval_functions = {
-    IntervalFunction.new(5, function()
-      -- run no more often than once every 5 seconds
-      -- chill interval to check on states that don't
-      -- need to feel so snappy
-    end),
+    -- IntervalFunction.new(5, function()
+    --   -- run no more often than once every 5 seconds
+    --   -- chill interval to check on states that don't
+    --   -- need to feel so snappy
+    -- end),
 
-    IntervalFunction.new(-15, function ()
-      -- run every 15 ticks, ~0.5 seconds
-      -- maybe a good interval for updating some states
-      -- in a way that feels responsive, like selections
-    end)
+    -- IntervalFunction.new(-15, function ()
+    --   -- run every 15 ticks, ~0.5 seconds
+    --   -- maybe a good interval for updating some states
+    --   -- in a way that feels responsive, like selections
+    -- end)
   }
 
   return self._interval_functions


### PR DESCRIPTION
Custom `IntervalFunction` objects that can be lazily defined inside of `ReaSpeechUI:interval_functions` and will run at approximate intervals inside of the main `ReaSpeechUI:react()` invocation in the main loop.

I've initially provided a couple of examples in there with commented noop function bodies. 

I didn't realize until pretty far into this spike that `reaper.time_precise()` returns a fractional value, so my first idea was to be able to specify "ticks" via a negative interval. Not sure how I feel about it, but in local testing I got fairly consistent results. It doesn't seem at a first pass like any way you go is going to provide any more than approximations in this context - like, I can say "interval of five seconds" but can't guarantee more than "won't run again before five seconds have passed."

Happy to be wrong though 🙃