### PR TITLE
validate ImGui_Image reference in png_from_bytes

### DIFF
--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -351,15 +351,17 @@ function ReaSpeechUI:render_transcript_section()
 end
 
 function ReaSpeechUI.png_from_bytes(image_key)
-    if not IMAGES[image_key] or not IMAGES[image_key].bytes then
-      return
-    end
+  if not IMAGES[image_key] or not IMAGES[image_key].bytes then
+    return
+  end
 
-    local image = IMAGES[image_key]
+  local image = IMAGES[image_key]
 
-    image.imgui_image = image.imgui_image or ImGui.CreateImageFromMem(image.bytes)
+  if not ImGui.ValidatePtr(image.imgui_image, 'ImGui_Image*') then
+    image.imgui_image = ImGui.CreateImageFromMem(image.bytes)
+  end
 
-    ImGui.Image(ctx, image.imgui_image, image.width, image.height)
+  ImGui.Image(ctx, image.imgui_image, image.width, image.height)
 end
 
 function ReaSpeechUI:render_inputs()


### PR DESCRIPTION
After isolating where the crash was happening, it occurred to me that something about minimizing/restoring the ReaSpeech window caused ImGui to release its resources (in this case, the `ImGui_Image` `userdata` instances for each of the loaded pngs). 

This uses the provided `ValidatePtr` method to confirm that the cached object is still valid, recreating it if necessary.