### PR TITLE
TEAMTECH-126: Better whitespace handling in Transcript word editor

### DIFF
--- a/reascripts/ReaSpeech/source/TranscriptEditor.lua
+++ b/reascripts/ReaSpeech/source/TranscriptEditor.lua
@@ -217,7 +217,7 @@ end
 function TranscriptEditor:render_word_input()
   local rv, value = ImGui.InputText(ctx, 'word', self.editing.word.word)
   if rv then
-    value = value:gsub('%s+', '')
+    value = value:gsub('^%s*(.-)%s*$', '%1')
     if #value > 0 then
       self.editing.word.word = value
     end


### PR DESCRIPTION
The ticket mentioned options and ways to go, but it wasn't immediately clear how to pick this up to run with it. This small change just changes the whitespace stripping to only affect space around the word, not within it. 

When I tried this out in the editor, it felt kinda right? Like, if I'm adding a space inside of the word then that has some meaning to me. Seems like if it's about spacing the word in the greater surrounding context, maybe that should be in the purview of nudging or other similar actions. Happy to change my mind depending on where the conversation goes.

It'd be nice to get some further input on this either way.