### PR TITLE
Pin ctranslate2 to version 4.2.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -429,25 +429,36 @@ cron = ["capturer (>=2.4)"]
 
 [[package]]
 name = "ctranslate2"
-version = "4.3.0"
+version = "4.2.1"
 description = "Fast inference engine for Transformer models"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ctranslate2-4.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:aa32a75d27b9f096c4def39471d487cc51cd114f37fb8c821a6edd3c2baa1170"},
-    {file = "ctranslate2-4.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6a3205e6fcf9fac098520ad6096c46647a613d57df8e98d56c36289611690658"},
-    {file = "ctranslate2-4.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bbf9b8c2e1823e5be73146dceea2a14dc8b31521890e7f892228c109d98394d"},
-    {file = "ctranslate2-4.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51770268679240459ce6250d99c4d5204f0038a4cdd33c7c55cfa01af35616fa"},
-    {file = "ctranslate2-4.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:799614577f5646a3a5d9b4ef99730fe4f91ec759936465a81bf02182ae827650"},
-    {file = "ctranslate2-4.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:34b6999e4cf332cb7d2f259e23e11e0ad2f341501a1abea000d6bd0d7f1f395c"},
-    {file = "ctranslate2-4.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c33d1b2ae5b3c0650fbd259f063024738f97779500046b60fc36160fe30f3341"},
-    {file = "ctranslate2-4.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41be052c666a95dfbd1d5bd801a6807579dd10f6ea56eaebc61142d9b8e04a7b"},
-    {file = "ctranslate2-4.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db9c7242b46b84949a4ebf68d5d2f396c215379b547433482c4016d8735f92ec"},
-    {file = "ctranslate2-4.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:a50a38bb99af3c25614847f40d341a5467dd8917e1a0e60f2c86854c4a2d6609"},
-    {file = "ctranslate2-4.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b866dcbbe1f3c46f240f9ab91a7597c5d2d7733de769488410ccf56eb4b2dabb"},
-    {file = "ctranslate2-4.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dec27852dbbcb98380edcfc11d09403902ce4a29d5e893578e3ba0e4037ff45d"},
-    {file = "ctranslate2-4.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f18f09f3bf39429ebb9922559a76ff15c4808cb5981ee4c7d0d8938f427ea637"},
-    {file = "ctranslate2-4.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef80ce2e574284e4f5c4dd4373502058ffeec257f47514adb3fb29c104893478"},
+    {file = "ctranslate2-4.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8a98623342da8448043a32e3b20b7b6007d4893e7026a6f7ce6e5bed3ef07f5"},
+    {file = "ctranslate2-4.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:550b8014f51b0290a67a37017fcce743c59e2be5a3b7a209db4b1c9e4fb5236b"},
+    {file = "ctranslate2-4.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48dd15c8f1d55d58fed9c3d8f7d4e995b17e7dbdfc3c9b8cc9e79eee40be0ab8"},
+    {file = "ctranslate2-4.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1332436c4d5ebef57a5b6bec481bf89aa062aabc4a721e4b30a10016e044a28a"},
+    {file = "ctranslate2-4.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:f40e0552f096d2243d0286623ffed34f9fa7275cf0298ee44e1190078e2c8d7d"},
+    {file = "ctranslate2-4.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79112191709c802b9b66fdd1c4c4dc63d994e2facf9d1ab2561b9e291f0845ff"},
+    {file = "ctranslate2-4.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:463391dcf8c1327c196af813d953399ca60274ef3cf38d9776b8f8b0d2138d23"},
+    {file = "ctranslate2-4.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:549e4be62612271fcfe2cec9204b048777954dabb77af041ca0dc9cb6acfdbd8"},
+    {file = "ctranslate2-4.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a364ac0ddbe1abb35136261632e4e8cc6a820afbfdde3d2f4a40e5e7ee1e3ebc"},
+    {file = "ctranslate2-4.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:a2332da680c1f6904d7c67ff539ed5e2d80532b8e531e24ca68ef4fdf5ba729e"},
+    {file = "ctranslate2-4.2.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:75207688fc862457b578b5cf917e606283ab720822a3ba6d4ba405ddd53f33c3"},
+    {file = "ctranslate2-4.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41b5f401b7765c7d19d2b35e4d282b15f572d57cebdca5bd30a4deda076a05d2"},
+    {file = "ctranslate2-4.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174be98d48869053ac31d9c91c910f3860afff2a84139b6352bd9a11a7e99a5f"},
+    {file = "ctranslate2-4.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1681fb06fa5714e3d440b4a9fce8f1fb71cfadfcc912e0346eaea4385269b347"},
+    {file = "ctranslate2-4.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:c5b604b64138c4cf49a9fac1ebc7023e3ea2fe95fe7b42a9c7076f789fd5ce65"},
+    {file = "ctranslate2-4.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bb9069476266a82ffaacff681fd8a2dd249bac18064f766910b55cfd025efab8"},
+    {file = "ctranslate2-4.2.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c6aff28115b00ec839c4f106feb2fb8de5cd75314a277fa72e1953efa3e251b2"},
+    {file = "ctranslate2-4.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:998b1fc6da60863b4e9c48502cae5956520eeebeacef3838a443c538e846089c"},
+    {file = "ctranslate2-4.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47635ca9b58cb0946eefb187ad2963fea3f3c44093f8059ec37cf4d9ab5a9810"},
+    {file = "ctranslate2-4.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:ece6c255bad7f76ad92e6a2345685c85f8c0547a06861ec71672a6a82c519944"},
+    {file = "ctranslate2-4.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9f4edde5d86466d85b6d6626f90cc0e40f1304c9ad7471e8363e06cf2c96ec2e"},
+    {file = "ctranslate2-4.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d478b00a9b2fc78aae815512dfea76d6e15c71f41c31e95b3d5129a1387cf1f5"},
+    {file = "ctranslate2-4.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f65820714a81df2ad707e38ebbffdaa4c2b76bef80063684921ab4378fdf659"},
+    {file = "ctranslate2-4.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1d6726c7ed4e528a18c48487a5f5f3dcc8d66d551069f319c044de0ae8c8015"},
+    {file = "ctranslate2-4.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:f889e37cb89e663be300a23e1fca4e8c8d3191615ec036c89e49b504b621ba90"},
 ]
 
 [package.dependencies]
@@ -2087,4 +2098,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "94651f13845c2d552effeb8b307a0c4b3c80ad8f48c2695bc626ce0b21d55be8"
+content-hash = "bde6c27a72c4e0d9154c2889c6098ea298c76cfd862aa14c80dab89a841da0ae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ torch = [
 jinja2 = "^3.1.2"
 celery = "^5.2.7"
 redis = "^4.5.4"
+ctranslate2 = "4.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
Due to a file size limit in PyPI, the latest version of ctranslate (4.3.0) can't be downloaded at this time. Pin ctranslate2 to version 4.2.1 to fix the build for now.

https://github.com/OpenNMT/CTranslate2/issues/1712