### PR TITLE
'delimiter' and 'include header' options for CSV export

### DIFF
--- a/reascripts/ReaSpeech/source/CSVWriter.lua
+++ b/reascripts/ReaSpeech/source/CSVWriter.lua
@@ -11,15 +11,19 @@ CSVWriter = Polo {
     { char = ';',  name = 'Semicolon' },
     { char = '\t', name = 'Tab' },
   },
-  DEFAULT_DELIMITER = ',',
+
+  new = function(options)
+    options = options or {}
+    return {
+      file = options.file,
+      delimiter = options.delimiter or ',',
+      include_header_row = options.include_header_row or false,
+    }
+  end,
 }
 
 function CSVWriter:init()
   assert(self.file, 'missing file')
-
-  self.options = self.options or {}
-  self.delimiter = self.options.delimiter or CSVWriter.DEFAULT_DELIMITER
-  self.include_header_row = self.options.include_header_row or false
 end
 
 CSVWriter.format_time = function (time)

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -317,6 +317,10 @@ function TranscriptExportFormat.options_csv(options)
 end
 
 function TranscriptExportFormat.writer_csv(transcript, output_file, options)
-  local writer = CSVWriter.new { file = output_file, options = options }
+  local writer = CSVWriter.new {
+    file = output_file,
+    delimiter = options.delimiter,
+    include_header_row = options.include_header_row
+  }
   writer:write(transcript)
 end

--- a/reascripts/ReaSpeech/tests/TestCSVWriter.lua
+++ b/reascripts/ReaSpeech/tests/TestCSVWriter.lua
@@ -86,7 +86,7 @@ function TestCSVWriter:testCustomDelimiter()
       table.insert(output, s)
     end
   }
-  local writer = CSVWriter.new { file = f, options = { delimiter = '\t' } }
+  local writer = CSVWriter.new { file = f, delimiter = '\t' }
   writer:write(t)
   local output_str = table.concat(output)
   lu.assertEquals(output_str, '1\t"00:00:00,000"\t"00:00:01,000"\t"hello"\t"test_audio.wav"\n2\t"00:00:01,000"\t"00:00:02,000"\t"world"\t"test_audio.wav"\n3\t"00:00:02,000"\t"00:00:03,000"\t"something in ""quotes"""\t"test_audio.wav"\n')
@@ -101,7 +101,7 @@ function TestCSVWriter:testIncludeHeaderRow()
       table.insert(output, s)
     end
   }
-  local writer = CSVWriter.new { file = f, options = { include_header_row = true } }
+  local writer = CSVWriter.new { file = f, include_header_row = true }
   writer:write(t)
   local output_str = table.concat(output)
   lu.assertEquals(output_str, '"Sequence Number","Start Time","End Time","Text","File"\n1,"00:00:00,000","00:00:01,000","hello","test_audio.wav"\n2,"00:00:01,000","00:00:02,000","world","test_audio.wav"\n3,"00:00:02,000","00:00:03,000","something in ""quotes""","test_audio.wav"\n')


### PR DESCRIPTION
Offer a user a combo box to select a delimiter and a checkbox to "include header row" for CSV export.

Future enhancements could include a custom delimiter input and/or column reordering. Neither of those seemed super important to dive into at the moment - I was mostly looking to see how well the "per-format export options" work performed when trying to actually add this custom functionality (answer: so far, so good).