### PR TITLE
"one object per segment" export option for json

### DIFF
--- a/reascripts/ReaSpeech/tests/TestCSVWriter.lua
+++ b/reascripts/ReaSpeech/tests/TestCSVWriter.lua
@@ -5,6 +5,7 @@ app = {}
 local lu = require('luaunit')
 
 require('mock_reaper')
+require('Polo')
 require('source/CSVWriter')
 require('source/Transcript')
 

--- a/reascripts/ReaSpeech/tests/TestSRTWriter.lua
+++ b/reascripts/ReaSpeech/tests/TestSRTWriter.lua
@@ -5,6 +5,7 @@ app = {}
 local lu = require('luaunit')
 
 require('mock_reaper')
+require('Polo')
 require('source/SRTWriter')
 require('source/Transcript')
 


### PR DESCRIPTION
Currently the JSON export format exports one big [valid] JSON object with a list key called `segments`. This option removes the outer layer of the object and instead provides a valid segment-level object per-line instead. No one was really clamoring for this, but I've run into instances in the past where a json-driven pipeline worked with data at this level (cases like logging, where you don't ever consume a whole object representing "all" of the data).

Perfectly content if we decide we don't want this, of course. :)

Unrelated, it was interesting how many places I had to add `require('Polo')`. This tripped me up for a moment while working with the tests. I was confused that I was getting messages like:

```lua5.3: ./source/Transcript.lua:7: attempt to call a nil value (global 'Polo')```

Like, wtf? I added the require line to `TestTranscript`! Eventually I noticed: 
```
stack traceback:
	./source/Transcript.lua:7: in main chunk
	[C]: in function 'require'
	tests/TestCSVWriter.lua:9: in main chunk
	[C]: in ?
```

...oh! It's the other tests that use `Transcript` that were failing. Obvious after that realization, of course.