### PR TITLE
'coordinates' (x1, y1, x2, y2) options for SRT export

### DIFF
--- a/reascripts/ReaSpeech/source/SRTWriter.lua
+++ b/reascripts/ReaSpeech/source/SRTWriter.lua
@@ -4,17 +4,27 @@
 
 ]]--
 
-SRTWriter = {
+SRTWriter = Polo {
   TIME_FORMAT = '%02d:%02d:%02d,%03d',
 }
 
-SRTWriter.__index = SRTWriter
+function SRTWriter:init()
+  assert(self.file, 'missing file')
 
-SRTWriter.new = function (o)
-  o = o or {}
-  setmetatable(o, SRTWriter)
-  o:init()
-  return o
+  self.options = self.options or {}
+
+  if self.options.coords_x1 then
+    self.coords_x1 = self.options.coords_x1
+  end
+  if self.options.coords_y1 then
+    self.coords_y1 = self.options.coords_y1
+  end
+  if self.options.coords_x2 then
+    self.coords_x2 = self.options.coords_x2
+  end
+  if self.options.coords_y2 then
+    self.coords_y2 = self.options.coords_y2
+  end
 end
 
 SRTWriter.format_time = function (time)
@@ -23,10 +33,6 @@ SRTWriter.format_time = function (time)
   local minutes = math.floor(time / 60) % 60
   local hours = math.floor(time / 3600)
   return string.format(SRTWriter.TIME_FORMAT, hours, minutes, seconds, milliseconds)
-end
-
-function SRTWriter:init()
-  assert(self.file, 'missing file')
 end
 
 function SRTWriter:write(transcript)
@@ -53,8 +59,35 @@ function SRTWriter:write_line(line, sequence_number, start, end_)
   self.file:write(start_str)
   self.file:write(' --> ')
   self.file:write(end_str)
+  self.file:write(self:coords())
   self.file:write('\n')
   self.file:write(line)
   self.file:write('\n')
   self.file:write('\n')
+end
+
+function SRTWriter:coords()
+  local coords = {}
+
+  if self.coords_x1 then
+    table.insert(coords, 'X1:' .. self.coords_x1)
+  end
+
+  if self.coords_x2 then
+    table.insert(coords, 'X2:' .. self.coords_x2)
+  end
+
+  if self.coords_y1 then
+    table.insert(coords, 'Y1:' .. self.coords_y1)
+  end
+
+  if self.coords_y2 then
+    table.insert(coords, 'Y2:' .. self.coords_y2)
+  end
+
+  if #coords == 0 then
+    return ''
+  end
+
+  return ' ' .. table.concat(coords, ' ')
 end


### PR DESCRIPTION
I found after some quick research online that the SRT format supports supplying four coordinate values after each timecode line. It's not immediately clear what the second pair is for (bottom-right, perhaps?). Will follow up with more research.

This contains a similar initializer to #26 ("initialize with options table, then pull individual values out into class instance fields in `init`"). It's still up in the PR air how to tweak that. Once that's clear I'll apply it here as well.