### PR TITLE
luacheck: ignore unused parameters starting with '_'

### DIFF
--- a/reascripts/ReaSpeech/.luacheckrc
+++ b/reascripts/ReaSpeech/.luacheckrc
@@ -10,4 +10,4 @@ globals = {
 
 allow_defined = true
 color = false
-ignore = {"212/self", "432/self", "631"}
+ignore = {"212/self", "212/_.*", "432/self", "631"}

--- a/reascripts/common/.luacheckrc
+++ b/reascripts/common/.luacheckrc
@@ -3,4 +3,4 @@ globals = {
 
 allow_defined = true
 color = false
-ignore = {"212/self", "432/self", "631"}
+ignore = {"212/self", "212/_.*", "432/self", "631"}


### PR DESCRIPTION
Not sure if this is because I upgraded luacheck, but I get build failures without this change