### PR TITLE
Don't freeze columns, fixes wasted space issue

### DIFF
--- a/reascripts/ReaSpeech/source/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptUI.lua
@@ -168,7 +168,7 @@ function TranscriptUI:render_table()
         ImGui.TableSetupColumn(ctx, column, column_flags, init_width)
       end
 
-      ImGui.TableSetupScrollFreeze(ctx, num_columns, 1)
+      ImGui.TableSetupScrollFreeze(ctx, 0, 1)
       ImGui.TableHeadersRow(ctx)
 
       self:sort_table()


### PR DESCRIPTION
We were passing num_columns to TableSetupScrollFreeze, which made it freeze all the columns and not just the header row. This was causing hidden columns to take up space, as @mikeylove discovered!