### PR TITLE
Run ReaSpeech Docker services as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM swaggerapi/swagger-ui:v4.18.2 AS swagger-ui
 FROM python:3.10-slim
 
-ARG UID=1001
-ARG GID=1001
+ARG SERVICE_USER=service
+ARG SERVICE_UID=1001
+ARG SERVICE_GID=1001
 
 ENV POETRY_VENV=/app/.venv
 
@@ -39,10 +40,10 @@ RUN make publish
 WORKDIR /app
 RUN rm -rf reascripts
 
-RUN groupadd -g $GID service || true
-RUN useradd -u $UID -g $GID -d /app -s /usr/sbin/nologin service || true
-RUN chown -R service:service .
-USER service
+RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
+RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
+RUN chown -R $SERVICE_UID:$SERVICE_GID .
+USER $SERVICE_USER
 
 ENTRYPOINT ["python3", "app/run.py"]
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,8 +1,9 @@
 FROM swaggerapi/swagger-ui:v4.18.2 AS swagger-ui
 FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
-ARG UID=1001
-ARG GID=1001
+ARG SERVICE_USER=service
+ARG SERVICE_UID=1001
+ARG SERVICE_GID=1001
 
 ENV PYTHON_VERSION=3.10
 ENV POETRY_VENV=/app/.venv
@@ -51,10 +52,10 @@ RUN make publish
 WORKDIR /app
 RUN rm -rf reascripts
 
-RUN groupadd -g $GID service || true
-RUN useradd -u $UID -g $GID -d /app -s /usr/sbin/nologin service || true
-RUN chown -R service:service .
-USER service
+RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
+RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
+RUN chown -R $SERVICE_UID:$SERVICE_GID .
+USER $SERVICE_USER
 
 ENTRYPOINT ["python3", "app/run.py"]
 


### PR DESCRIPTION
Used ARGs for the service account name and UID/GID so they can be overridden, if desired.

Verified that the service works and no warning about "root" user is displayed at startup. Models are now cached in /app/.cache instead of /root/.cache.
