### PR TITLE
Avoid use of chown -R

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,30 +20,31 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     redis \
     && rm -rf /var/lib/apt/lists/*
 
+RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
+RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
+
+COPY --chown=$SERVICE_UID:$SERVICE_GID . /app
+COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui.css /app/swagger-ui-assets/swagger-ui.css
+COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js /app/swagger-ui-assets/swagger-ui-bundle.js
+RUN chown $SERVICE_UID:$SERVICE_GID /app
+
+USER $SERVICE_USER
+
+WORKDIR /app
+
 RUN python3 -m venv $POETRY_VENV \
     && $POETRY_VENV/bin/pip install -U pip setuptools \
     && $POETRY_VENV/bin/pip install poetry==1.6.1
 
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
 
-WORKDIR /app
-
-COPY . /app
-COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui.css swagger-ui-assets/swagger-ui.css
-COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js swagger-ui-assets/swagger-ui-bundle.js
-
 RUN poetry config virtualenvs.in-project true
-RUN poetry install && rm -rf /root/.cache/pypoetry
+RUN poetry install && rm -rf /app/.cache/pypoetry
 
 WORKDIR /app/reascripts/ReaSpeech
 RUN make publish
 WORKDIR /app
 RUN rm -rf reascripts
-
-RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
-RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
-RUN chown -R $SERVICE_UID:$SERVICE_GID .
-USER $SERVICE_USER
 
 ENTRYPOINT ["python3", "app/run.py"]
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -27,35 +27,36 @@ RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
     ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
     ln -s -f /usr/bin/pip3 /usr/bin/pip
 
+RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
+RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
+
+COPY --chown=$SERVICE_UID:$SERVICE_GID . /app
+COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui.css /app/swagger-ui-assets/swagger-ui.css
+COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js /app/swagger-ui-assets/swagger-ui-bundle.js
+RUN chown $SERVICE_UID:$SERVICE_GID /app
+
+USER $SERVICE_USER
+
+WORKDIR /app
+
 RUN python3 -m venv $POETRY_VENV \
     && $POETRY_VENV/bin/pip install -U pip setuptools \
     && $POETRY_VENV/bin/pip install poetry==1.6.1
 
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
 
-WORKDIR /app
-
-COPY poetry.lock pyproject.toml ./
+COPY --chown=$SERVICE_UID:$SERVICE_GID poetry.lock pyproject.toml ./
 
 RUN poetry config virtualenvs.in-project true
 RUN poetry install --no-root
 
-COPY . .
-COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui.css swagger-ui-assets/swagger-ui.css
-COPY --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js swagger-ui-assets/swagger-ui-bundle.js
-
-RUN poetry install && rm -rf /root/.cache/pypoetry
+RUN poetry install && rm -rf /app/.cache/pypoetry
 RUN $POETRY_VENV/bin/pip install --no-cache-dir torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch
 
 WORKDIR /app/reascripts/ReaSpeech
 RUN make publish
 WORKDIR /app
 RUN rm -rf reascripts
-
-RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
-RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
-RUN chown -R $SERVICE_UID:$SERVICE_GID .
-USER $SERVICE_USER
 
 ENTRYPOINT ["python3", "app/run.py"]
 


### PR DESCRIPTION
chown -R is extremely slow on Windows. Change Dockerfiles to use `--chown` argument to `COPY` instead, and switch users earlier so that files are created with the right ownership. /cc @smrl 