### PR TITLE
Display job status in progress bar

### DIFF
--- a/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
@@ -60,7 +60,12 @@ function ReaSpeechActionsUI:render()
     end
 
     ImGui.SameLine(ctx)
-    ImGui.ProgressBar(ctx, progress)
+    local overlay = string.format("%.0f%%", progress * 100)
+    local status = self.worker:status()
+    if status then
+      overlay = overlay .. ' - ' .. status
+    end
+    ImGui.ProgressBar(ctx, progress, nil, nil, overlay)
   end
   ImGui.Dummy(ctx,0, 5)
 end

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -89,6 +89,12 @@ function ReaSpeechWorker:progress()
   return completed_job_count / job_count
 end
 
+function ReaSpeechWorker:status()
+  if self.active_job and self.active_job.job then
+    return self.active_job.job.job_status
+  end
+end
+
 function ReaSpeechWorker:cancel()
   if self.active_job then
     if self.active_job.job and self.active_job.job.job_id then
@@ -156,6 +162,7 @@ function ReaSpeechWorker:handle_job_status(active_job, response)
   end
 
   active_job.job.job_id = response.job_id
+  active_job.job.job_status = response.job_status
 
   if not response.job_status then
     return false


### PR DESCRIPTION
ImGui progress bars have an optional "overlay" parameter which controls the text. We can use this to append the job state when it is available.