### PR TITLE
docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Publish Docker Image
+on:
+  push:
+    tags:        
+      - '*'
+    branches:
+      - debug
+
+env:
+  DOCKER_USER: ${{secrets.DOCKER_USER}}
+  DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+  REPO_NAME: ${{secrets.REPO_NAME}}
+jobs:
+  build:
+    environment: deploy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - docker_file: Dockerfile
+            platforms: linux/arm64,linux/amd64
+          - docker_file: Dockerfile.gpu
+            tag_extension: -gpu
+            platforms: linux/amd64
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ env.DOCKER_USER }}
+        password: ${{ env.DOCKER_PASSWORD }}
+    - name: Build and Publish the Docker debug image
+      if: github.ref == 'refs/heads/debug'
+      run: |
+        DOCKER_IMAGE_DEBUG=$DOCKER_USER/$REPO_NAME:debug${{ matrix.tag_extension }}
+        docker buildx build . --no-cache --platform=${{ matrix.platforms }} -t "${DOCKER_IMAGE_DEBUG}" -f ${{ matrix.docker_file }} --push
+    - name: Build and Publish the Docker image
+      if: github.ref != 'refs/heads/debug'
+      run: |
+        DOCKER_IMAGE_LATEST=$DOCKER_USER/$REPO_NAME:latest${{ matrix.tag_extension }}
+        DOCKER_IMAGE_VERSION=$DOCKER_USER/$REPO_NAME:$GITHUB_REF_NAME${{ matrix.tag_extension }}
+        docker buildx build . --no-cache --platform=${{ matrix.platforms }} -t "${DOCKER_IMAGE_LATEST}" -t "${DOCKER_IMAGE_VERSION}" -f ${{ matrix.docker_file }} --push


### PR DESCRIPTION
this is almost entirely copypasta from `whisper-asr-webservice` - the only difference is the `deploy` environment constraint.

- any named release tags will publish cpu (amd/arm) and gpu (amd) under both `<tag name>` and "latest"
- any push to a branch called "debug" will publish "debug"-tagged images
- requires an environment called "deploy" with secrets set for `DOCKER_USER`, `DOCKER_PASSWORD` and `REPO_NAME`