### PR TITLE
Add ability to use HTTPS for API endpoints

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,7 +26,8 @@
       reascriptLinks.forEach((reascriptLink) => {
         const name = reascriptLink.dataset.name;
         const host = location.host;
-        reascriptLink.href = '/reascript?name=' + name + '&host=' + host;
+        const protocol = location.protocol;
+        reascriptLink.href = '/reascript?name=' + name + '&host=' + host + '&protocol=' + protocol;
       });
     </script>
   </body>

--- a/app/templates/reascript.lua
+++ b/app/templates/reascript.lua
@@ -3,6 +3,7 @@
 Script = {
   name = "{{ name }}",
   host = "{{ host }}",
+  protocol = "{{ protocol }}",
   lua = _VERSION:match('[%d.]+'),
   timeout = 30000,
 }
@@ -16,7 +17,7 @@ function Script:load()
     curl = "/usr/bin/curl"
   end
   local command = curl
-    .. " -sSf http://" .. self.host .. "/static/reascripts/" .. self.name
+    .. " -sSf " .. self.protocol .. "//" .. self.host .. "/static/reascripts/" .. self.name
     .. "/" .. self.name .. "-" .. self.lua .. '.luac -o "' .. tempfile .. '"'
   local result = reaper.ExecProcess(command, self.timeout)
   local offset = result:find("\n")

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -98,11 +98,12 @@ async def reaspeech(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
 @app.get("/reascript", response_class=PlainTextResponse, include_in_schema=False)
-async def reascript(request: Request, name: str, host: str):
+async def reascript(request: Request, name: str, host: str, protocol: str):
     return templates.TemplateResponse("reascript.lua", {
             "request": request,
             "name": name,
-            "host": host
+            "host": host,
+            "protocol": protocol
         },
         media_type='application/x-lua',
         headers={

--- a/reascripts/ReaSpeech/ReaSpeechDev.lua
+++ b/reascripts/ReaSpeech/ReaSpeechDev.lua
@@ -40,6 +40,7 @@ end
 Script = {
   name = "ReaSpeechDev",
   host = "localhost:9000",
+  protocol = "http:",
   lua = _VERSION:match('[%d.]+'),
   timeout = 30000,
 }

--- a/reascripts/ReaSpeech/source/Fonts.lua
+++ b/reascripts/ReaSpeech/source/Fonts.lua
@@ -29,7 +29,8 @@ function Fonts:load()
     return
   end
 
-  local icons_url = 'http://' .. Script.host .. '/static/reascripts/ReaSpeech/icons.ttf'
+  local protocol = Script.protocol or 'http:'
+  local icons_url = protocol .. '//' .. Script.host .. '/static/reascripts/ReaSpeech/icons.ttf'
   local icons_file = Tempfile:name()
 
   local curl = "curl"

--- a/reascripts/ReaSpeech/source/ReaSpeechAPI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechAPI.lua
@@ -9,10 +9,9 @@ ReaSpeechAPI = {
   base_url = nil,
 }
 
--- Initialize the module with the given base URL
--- Example: "http://localhost:9000"
-function ReaSpeechAPI:init(base_url)
-  self.base_url = base_url
+function ReaSpeechAPI:init(host, protocol)
+  protocol = protocol or 'http:'
+  self.base_url = protocol .. '//' .. host
 end
 
 function ReaSpeechAPI:get_api_url(remote_path)

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -25,7 +25,7 @@ function ReaSpeechUI:init()
   self.responses = {}
   self.logs = {}
 
-  ReaSpeechAPI:init('http://' .. Script.host)
+  ReaSpeechAPI:init(Script.host, Script.protocol)
 
   self.worker = ReaSpeechWorker.new({
     requests = self.requests,


### PR DESCRIPTION
This change avoids hardcoding "http:" as the protocol for API endpoints. This should enable ReaSpeech to use HTTPS in a hosted environment.

For now, local Docker usage is still done via HTTP. To enable HTTPS on localhost, we would need to consider using self-signed certificates.