### PR TITLE
Add "--http1.1" to curl requests

### DIFF
--- a/app/templates/reascript.lua
+++ b/app/templates/reascript.lua
@@ -17,7 +17,7 @@ function Script:load()
     curl = "/usr/bin/curl"
   end
   local command = curl
-    .. " -sSf " .. self.protocol .. "//" .. self.host .. "/static/reascripts/" .. self.name
+    .. " --http1.1 -sSf " .. self.protocol .. "//" .. self.host .. "/static/reascripts/" .. self.name
     .. "/" .. self.name .. "-" .. self.lua .. '.luac -o "' .. tempfile .. '"'
   local result = reaper.ExecProcess(command, self.timeout)
   local offset = result:find("\n")

--- a/reascripts/ReaSpeech/source/Fonts.lua
+++ b/reascripts/ReaSpeech/source/Fonts.lua
@@ -39,6 +39,7 @@ function Fonts:load()
   end
   local command = (
     curl
+    .. ' --http1.1'
     .. ' "' .. icons_url .. '"'
     .. ' -o "' .. icons_file .. '"'
   )

--- a/reascripts/ReaSpeech/source/ReaSpeechAPI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechAPI.lua
@@ -45,6 +45,7 @@ function ReaSpeechAPI:fetch_json(url_path, http_method, error_handler, timeout_h
   local command = table.concat({
     curl,
     ' "', api_url, '"',
+    ' --http1.1',
     ' -H "accept: application/json"',
     http_method_argument,
     ' -m ', self.CURL_TIMEOUT_SECONDS,
@@ -118,6 +119,7 @@ function ReaSpeechAPI:fetch_large(url_path, http_method)
   local command = table.concat({
     curl,
     ' "', api_url, '"',
+    ' --http1.1',
     ' -H "accept: application/json"',
     http_method_argument,
     ' -i ',
@@ -162,6 +164,7 @@ function ReaSpeechAPI:post_request(url_path, data, file_path)
   local command = table.concat({
     curl,
     ' "', api_url, '?', table.concat(query, '&'), '"',
+    ' --http1.1',
     ' -H "accept: application/json"',
     ' -H "Content-Type: multipart/form-data"',
     ' -F ', self:_maybe_quote('audio_file=@"' .. file_path .. '"'),


### PR DESCRIPTION
Requests were failing when trying to use a huggingface-hosted instance of ReaSpeech that was auto-negotiating a HTTP2 session which our response parsing wasn't ready for (matching the main response header - we're looking for something formatted like "HTTP/x.x nnn" but apparently HTTP/2 confidently says "let there be no indicated decimal in the version").

Since we're in curl-in-reaper-land, this change just asks curl to force a HTTP/1.1 session instead. Modified are 1) the loader, 2) the font fetcher and 3) the `ReaSpeechAPI` processing calls.