### PR TITLE
#63 - optional swagger UI

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -33,6 +33,9 @@ argmap = {
     '--build-reascripts': {
         'action': 'store_true',
         'help': 'Build ReaScripts before starting' },
+    '--enable-swagger-ui': {
+        'action': 'store_true',
+        'help': 'Enable automatic Swagger UI for API' },
 }
 
 parser = argparse.ArgumentParser()
@@ -53,6 +56,9 @@ if args.build_reascripts:
     if os.system('cd reascripts/ReaSpeech && make') != 0:
         print('ReaScript build failed', file=sys.stderr)
         sys.exit(1)
+
+if args.enable_swagger_ui:
+    os.environ['ENABLE_SWAGGER_UI'] = '/docs'
 
 processes = {}
 

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -7,9 +7,11 @@
       <li class="nav-item">
         <a class="nav-link active" aria-current="page" href="/reaspeech">ReaSpeech</a>
       </li>
+      {% if docs_url != '': %}
       <li class="nav-item">
         <a class="nav-link" href="/docs">Whisper API</a>
       </li>
+      {% endif %}
     </ul>
   </div>
 </nav>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -7,9 +7,9 @@
       <li class="nav-item">
         <a class="nav-link active" aria-current="page" href="/reaspeech">ReaSpeech</a>
       </li>
-      {% if docs_url != '': %}
+      {% if docs_url: %}
       <li class="nav-item">
-        <a class="nav-link" href="/docs">Whisper API</a>
+        <a class="nav-link" href="{{ docs_url }}">Whisper API</a>
       </li>
       {% endif %}
     </ul>

--- a/app/webservice.py
+++ b/app/webservice.py
@@ -63,8 +63,10 @@ LANGUAGE_CODES = sorted(list(tokenizer.LANGUAGES.keys()))
 TASK_EXPIRATION_SECONDS = 30
 
 projectMetadata = importlib.metadata.metadata('reaspeech')
+docs_url = os.getenv('ENABLE_SWAGGER_UI', '')
+
 app = FastAPI(
-    # docs_url=None,
+    docs_url=docs_url or None,
     # redoc_url=None,
     title=projectMetadata['Name'].title().replace('-', ' '),
     description=projectMetadata['Summary'],
@@ -118,7 +120,7 @@ async def index():
 
 @app.get("/reaspeech", response_class=HTMLResponse, include_in_schema=False)
 async def reaspeech(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse("index.html", {"request": request, "docs_url": docs_url})
 
 @app.get("/reascript", response_class=PlainTextResponse, include_in_schema=False)
 async def reascript(request: Request, name: str, host: str, protocol: str):


### PR DESCRIPTION
introduce a new `run.py` argument: `--enable-swagger-ui`.

when supplied, `webservice.py` sets the FastAPI `docs_url` to `/docs` and the link shows up on the ReaSpeech install instructions and `/docs` is active. 

when not supplied, the link is not rendered and direct access of `/docs` now returns a 404.