### PR TITLE
Handle missing theme colors/styles, add TabSelected

### DIFF
--- a/reascripts/ReaSpeech/source/Theme.lua
+++ b/reascripts/ReaSpeech/source/Theme.lua
@@ -20,32 +20,33 @@ function Theme.init()
 
   Theme.theme = ImGuiTheme.new({
     colors = {
-      { ImGui.Col_WindowBg(), Theme.colors.dark_gray_semi_transparent },
-      { ImGui.Col_Border(), Theme.colors.black_near_transparent },
-      { ImGui.Col_Button(), Theme.colors.medium_gray_opaque },
-      { ImGui.Col_ButtonHovered(), Theme.colors.dark_gray_translucent },
-      { ImGui.Col_ButtonActive(), Theme.colors.dark_gray_opaque },
-      { ImGui.Col_TitleBg(), Theme.colors.dark_gray_semi_transparent },
-      { ImGui.Col_TitleBgActive(), Theme.colors.dark_blue_gray_opaque },
-      { ImGui.Col_FrameBg(), Theme.colors.dark_gray_translucent },
-      { ImGui.Col_FrameBgHovered(), Theme.colors.dark_gray_translucent },
-      { ImGui.Col_FrameBgActive(), Theme.colors.pink_opaque },
-      { ImGui.Col_CheckMark(), Theme.colors.pink_opaque },
-      { ImGui.Col_HeaderHovered(), Theme.colors.dark_gray_semi_opaque },
-      { ImGui.Col_HeaderActive(), Theme.colors.dark_gray_semi_transparent },
-      { ImGui.Col_Header(), Theme.colors.dark_gray_semi_opaque },
-      { ImGui.Col_Tab(), Theme.colors.dark_gray_opaque },
-      { ImGui.Col_TabActive(), Theme.colors.medium_gray_opaque },
-      { ImGui.Col_TabHovered(), Theme.colors.dark_gray_translucent },
+      { ImGui.Col_WindowBg, Theme.colors.dark_gray_semi_transparent },
+      { ImGui.Col_Border, Theme.colors.black_near_transparent },
+      { ImGui.Col_Button, Theme.colors.medium_gray_opaque },
+      { ImGui.Col_ButtonHovered, Theme.colors.dark_gray_translucent },
+      { ImGui.Col_ButtonActive, Theme.colors.dark_gray_opaque },
+      { ImGui.Col_TitleBg, Theme.colors.dark_gray_semi_transparent },
+      { ImGui.Col_TitleBgActive, Theme.colors.dark_blue_gray_opaque },
+      { ImGui.Col_FrameBg, Theme.colors.dark_gray_translucent },
+      { ImGui.Col_FrameBgHovered, Theme.colors.dark_gray_translucent },
+      { ImGui.Col_FrameBgActive, Theme.colors.pink_opaque },
+      { ImGui.Col_CheckMark, Theme.colors.pink_opaque },
+      { ImGui.Col_HeaderHovered, Theme.colors.dark_gray_semi_opaque },
+      { ImGui.Col_HeaderActive, Theme.colors.dark_gray_semi_transparent },
+      { ImGui.Col_Header, Theme.colors.dark_gray_semi_opaque },
+      { ImGui.Col_Tab, Theme.colors.dark_gray_opaque },
+      { ImGui.Col_TabActive, Theme.colors.medium_gray_opaque },
+      { ImGui.Col_TabHovered, Theme.colors.dark_gray_translucent },
+      { ImGui.Col_TabSelected, Theme.colors.medium_gray_opaque },
     },
 
     styles = {
-      { ImGui.StyleVar_FramePadding(), 10.0, 6.0 },
-      { ImGui.StyleVar_FrameRounding(), 12.0 },
-      { ImGui.StyleVar_GrabRounding(), 4.0 },
-      { ImGui.StyleVar_FrameBorderSize(), 1.0 },
-      { ImGui.StyleVar_WindowBorderSize(), 1.0 },
-      { ImGui.StyleVar_PopupBorderSize(), 1.0 }
+      { ImGui.StyleVar_FramePadding, 10.0, 6.0 },
+      { ImGui.StyleVar_FrameRounding, 12.0 },
+      { ImGui.StyleVar_GrabRounding, 4.0 },
+      { ImGui.StyleVar_FrameBorderSize, 1.0 },
+      { ImGui.StyleVar_WindowBorderSize, 1.0 },
+      { ImGui.StyleVar_PopupBorderSize, 1.0 }
     }
   })
 

--- a/reascripts/common/libs/ImGuiTheme.lua
+++ b/reascripts/common/libs/ImGuiTheme.lua
@@ -30,9 +30,6 @@ ImGuiTheme.new = function(theme_definition)
     styles = ImGuiTheme.get_attribute_values(theme_definition.styles),
   }
 
-  theme.color_count = #theme.colors
-  theme.style_count = #theme.styles
-
   setmetatable(theme, ImGuiTheme)
 
   theme:init()
@@ -68,12 +65,20 @@ ImGuiTheme.get_function = function(key, default)
 end
 
 function ImGuiTheme:push(ctx)
-  for i = 1, self.color_count do
-    self.f_color_push(ctx, self.colors[i][1], table.unpack(self.colors[i], 2))
+  self.color_count = 0
+  for i = 1, #self.colors do
+    if self.colors[i][1] then
+      self.f_color_push(ctx, self.colors[i][1], table.unpack(self.colors[i], 2))
+      self.color_count = self.color_count + 1
+    end
   end
 
-  for i = 1, self.style_count do
-    self.f_style_push(ctx, self.styles[i][1], table.unpack(self.styles[i], 2))
+  self.style_count = 0
+  for i = 1, #self.styles do
+    if self.styles[i][1] then
+      self.f_style_push(ctx, self.styles[i][1], table.unpack(self.styles[i], 2))
+      self.style_count = self.style_count + 1
+    end
   end
 end
 

--- a/reascripts/common/tests/TestImGuiTheme.lua
+++ b/reascripts/common/tests/TestImGuiTheme.lua
@@ -42,7 +42,6 @@ function TestImGuiTheme:testColorInit()
   lu.assertEquals(theme.colors[1][2], 0xFF0000FF)
   lu.assertEquals(theme.colors[2][1], "just a key")
   lu.assertEquals(theme.colors[2][2], 0x00FF0000)
-  lu.assertEquals(theme.color_count, 2)
 end
 
 function TestImGuiTheme:testColors()
@@ -87,7 +86,6 @@ function TestImGuiTheme:testStyleInit()
   lu.assertEquals(theme.styles[2][1], "multiple arguments")
   lu.assertEquals(theme.styles[2][2], 2.0)
   lu.assertEquals(theme.styles[2][3], 3.0)
-  lu.assertEquals(theme.style_count, 2)
 end
 
 function TestImGuiTheme:testStyles()


### PR DESCRIPTION
ImGui.Col_TabActive was renamed to ImGui.Col_TabSelected in the 0.9.2 upgrade to ReaImGui. We aren't using ReaImGui's shims, which might have worked around this issue, but nonetheless we shouldn't fail when a color/style function doesn't exist. This change includes nil-handling for ImGuiTheme so that missing colors/styles do not contribute to the color/style counts that are popped.