### PR TITLE
Docker Compose Linux fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,16 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     redis \
     && rm -rf /var/lib/apt/lists/*
 
-RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
-RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
+RUN groupadd -g $SERVICE_GID $SERVICE_USER \
+    && useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER \
+    || echo "Error creating service account: $?"
 
 COPY --chown=$SERVICE_UID:$SERVICE_GID . /app
 COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui.css /app/swagger-ui-assets/swagger-ui.css
 COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js /app/swagger-ui-assets/swagger-ui-bundle.js
 RUN chown $SERVICE_UID:$SERVICE_GID /app
 
-USER $SERVICE_USER
+USER $SERVICE_UID:$SERVICE_GID
 
 WORKDIR /app
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -27,15 +27,16 @@ RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
     ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
     ln -s -f /usr/bin/pip3 /usr/bin/pip
 
-RUN groupadd -g $SERVICE_GID $SERVICE_USER || true
-RUN useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER || true
+RUN groupadd -g $SERVICE_GID $SERVICE_USER \
+    && useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER \
+    || echo "Error creating service account: $?"
 
 COPY --chown=$SERVICE_UID:$SERVICE_GID . /app
 COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui.css /app/swagger-ui-assets/swagger-ui.css
 COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js /app/swagger-ui-assets/swagger-ui-bundle.js
 RUN chown $SERVICE_UID:$SERVICE_GID /app
 
-USER $SERVICE_USER
+USER $SERVICE_UID:$SERVICE_GID
 
 WORKDIR /app
 

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -12,11 +12,9 @@ services:
               count: 1
               capabilities: [gpu]
     environment:
-      - ASR_MODEL=small
       - ASR_ENGINE=faster_whisper
     ports:
       - "9000:9000"
-    restart: on-failure
     volumes:
       - ./app:/app/app
       - ./reascripts:/app/reascripts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,9 @@ services:
       dockerfile: Dockerfile
     entrypoint: ["python3", "app/run.py", "--build-reascripts"]
     environment:
-      - ASR_MODEL=small
       - ASR_ENGINE=faster_whisper
     ports:
       - "9000:9000"
-    restart: on-failure
     volumes:
       - ./app:/app/app
       - ./reascripts:/app/reascripts

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,6 +53,13 @@ command:
 docker compose -f docker-compose.gpu.yml up --build
 ```
 
+> **_NOTE:_** These instructions assume you are running a version of Docker
+> Compose that supports V2 syntax. If you are using an older version of
+> Docker Compose, you may need to replace "docker compose" with
+> "docker-compose" (hyphenated). See
+> [Migrate to Compose V2](https://docs.docker.com/compose/migrate/)
+> for details.
+
 This will build the Docker image and run it in a container. You can access the
 ReaSpeech web interface at [http://localhost:9000](http://localhost:9000).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ following command:
 ### CPU
 
 ```sh
-docker-compose up --build
+docker compose up --build
 ```
 
 ### GPU
@@ -50,7 +50,7 @@ the ReaSpeech Docker image using Docker Compose, you can use the following
 command:
 
 ```sh
-docker-compose -f docker-compose.gpu.yml up --build
+docker compose -f docker-compose.gpu.yml up --build
 ```
 
 This will build the Docker image and run it in a container. You can access the
@@ -115,7 +115,7 @@ an action in REAPER.
 The ReaSpeech web service is written in Python using the FastAPI framework. If
 you make changes to the web service code, you will need to restart the web
 service for the changes to take effect. You can do this by stopping the Docker
-container and running `docker-compose up` again. You can also restart the
+container and running `docker compose up` again. You can also restart the
 container by clicking the "Restart" button in the Docker Desktop interface.
 
 ## Environment Variables
@@ -157,22 +157,18 @@ ReaSpeech service.
 To fix this issue, you can use the `SERVICE_UID` and `SERVICE_GID` Dockerfile
 arguments. By default, the service runs as the `service` user with
 UID 1001 and GID 1001. If you need to change these values, you can set the
-`SERVICE_UID` and `SERVICE_GID` environment variables when running the Docker
-container. For example:
-
-```sh
-docker run -d -p 9000:9000 -e SERVICE_USER=app -e SERVICE_UID=1000 -e SERVICE_GID=1000 techaudiodoc/reaspeech:latest
-```
-
-When using Docker Compose, you can set these environment variables in the
+`SERVICE_UID` and `SERVICE_GID` environment variables in the
 `docker-compose.yml` or `docker-compose.gpu.yml` file. For example:
 
 ```yaml
 services:
   reaspeech:
-    environment:
-      - SERVICE_UID=1000
-      - SERVICE_GID=1000
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - SERVICE_UID=1000
+        - SERVICE_GID=1000
 ```
 
 ## Restart Behavior

--- a/docs/development.md
+++ b/docs/development.md
@@ -157,8 +157,8 @@ ReaSpeech service.
 To fix this issue, you can use the `SERVICE_UID` and `SERVICE_GID` Dockerfile
 arguments. By default, the service runs as the `service` user with
 UID 1001 and GID 1001. If you need to change these values, you can set the
-`SERVICE_UID` and `SERVICE_GID` environment variables in the
-`docker-compose.yml` or `docker-compose.gpu.yml` file. For example:
+`SERVICE_UID` and `SERVICE_GID` build arguments in the `docker-compose.yml` or
+`docker-compose.gpu.yml` file. For example:
 
 ```yaml
 services:


### PR DESCRIPTION
Some modifications to make development on Linux easier:

- Improve error handling and stick to uid:gid for all user settings in Dockerfiles
- Update documentation and clean up docker-compose*.yml files

In order to run Docker Compose on Linux, it's nearly always going to be necessary to add SERVICE_UID and SERVICE_GID args to docker-compose.yml so that they match up with the current user. I looked into ways to automate this, but it seems like Docker does not make this very easy. See ingyhere's comments and linked articles on https://stackoverflow.com/questions/56844746/how-to-set-uid-and-gid-in-docker-compose