### PR TITLE
Fix sorting for transcript table

### DIFF
--- a/reascripts/ReaSpeech/source/Transcript.lua
+++ b/reascripts/ReaSpeech/source/Transcript.lua
@@ -94,6 +94,8 @@ function Transcript:sort(column, ascending)
     local a_val, b_val = a:get(column), b:get(column)
     if a_val == nil then a_val = '' end
     if b_val == nil then b_val = '' end
+    if type(a_val) == 'table' then a_val = table.concat(a_val, ', ') end
+    if type(b_val) == 'table' then b_val = table.concat(b_val, ', ') end
     if not ascending then
       a_val, b_val = b_val, a_val
     end

--- a/reascripts/ReaSpeech/source/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptUI.lua
@@ -314,24 +314,27 @@ end
 
 function TranscriptUI:sort_table()
   local specs_dirty, has_specs = ImGui.TableNeedSort(ctx)
-  if has_specs and specs_dirty then
-    local columns = self.transcript:get_columns()
-    local column = nil
-    local ascending = true
+  if not specs_dirty then return end
 
-    for next_id = 0, math.huge do
-      local ok, _, col_idx, _, sort_direction =
-        ImGui.TableGetColumnSortSpecs(ctx, next_id)
-      if not ok then break end
+  if not has_specs then
+    self.transcript:update()
+    return
+  end
 
-      column = columns[col_idx]
-      ascending = (sort_direction == ImGui.SortDirection_Ascending())
-    end
+  local columns = self.transcript:get_columns()
+  local column = nil
+  local ascending = true
 
-    if column then
-      self.transcript:sort(column, ascending)
-    else
-      self.transcript:update()
-    end
+  for next_id = 0, math.huge do
+    local ok, col_idx, _, sort_direction =
+      ImGui.TableGetColumnSortSpecs(ctx, next_id)
+    if not ok then break end
+
+    column = columns[col_idx]
+    ascending = (sort_direction == ImGui.SortDirection_Ascending())
+  end
+
+  if column then
+    self.transcript:sort(column, ascending)
   end
 end

--- a/reascripts/ReaSpeech/tests/TestTranscript.lua
+++ b/reascripts/ReaSpeech/tests/TestTranscript.lua
@@ -198,13 +198,15 @@ function TestTranscript:testSort()
     id = 1,
     start = 1.0,
     end_ = 2.0,
-    text = "test 1"
+    text = "test 1",
+    tokens = {3, 2, 1},
   })
   t:add_segment(self.segment {
     id = 2,
     start = 2.0,
     end_ = 3.0,
-    text = "test 2"
+    text = "test 2",
+    tokens = {1, 2, 3},
   })
   t:update()
   t:sort('id', true)
@@ -212,6 +214,10 @@ function TestTranscript:testSort()
   lu.assertEquals(segments[1]:get('id'), 1)
   lu.assertEquals(segments[2]:get('id'), 2)
   t:sort('id', false)
+  segments = t:get_segments()
+  lu.assertEquals(segments[1]:get('id'), 2)
+  lu.assertEquals(segments[2]:get('id'), 1)
+  t:sort('tokens', true)
   segments = t:get_segments()
   lu.assertEquals(segments[1]:get('id'), 2)
   lu.assertEquals(segments[2]:get('id'), 1)


### PR DESCRIPTION
The return values for ImGui.TableGetColumnSortSpecs changed in https://github.com/cfillion/reaimgui/commit/316e66e35fba56664fbeca83a7d5ccd78dc20b8b which is why column sorting stopped working. Resetting to the default order was also broken, possibly due to a change in behavior of the "specs_dirty" result.

Also fixed is sorting columns with table values, which fixes behavior for the hidden "tokens" column.