### PR TITLE
Extract a CurlRequest class

### DIFF
--- a/reascripts/ReaSpeech/.luacheckrc
+++ b/reascripts/ReaSpeech/.luacheckrc
@@ -7,6 +7,7 @@ globals = {
   "IMAGES",
   "Polo",
   "ReaUtil",
+  "table",
 }
 
 allow_defined = true

--- a/reascripts/ReaSpeech/source/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/CurlRequest.lua
@@ -72,7 +72,7 @@ function CurlRequest:ready()
     return true
   end
 
-  if not self.check_sentinel(self.sentinel_file) then
+  if not self:check_sentinel() then
     return false
   end
 
@@ -289,8 +289,8 @@ function CurlRequest:curl_timeout_argument()
   return ' -m ' .. self.curl_timeout
 end
 
-CurlRequest.check_sentinel = function(filename)
-  local sentinel = io.open(filename, 'r')
+function CurlRequest:check_sentinel()
+  local sentinel = io.open(self.sentinel_file, 'r')
 
   if not sentinel then
     return false

--- a/reascripts/ReaSpeech/source/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/CurlRequest.lua
@@ -1,0 +1,189 @@
+--[[
+
+  CurlRequest.lua - wrapper interface for curl
+
+]]--
+
+CurlRequest = Polo {
+  DEFAULT_HTTP_METHOD = 'GET',
+  DEFAULT_HEADERS = {
+    ['accept'] = 'application/json',
+  },
+  DEFAULT_CURL_TIMEOUT = 0,
+  BASE_CURL_OPTIONS = {
+    '--http1.1', -- force HTTP/1.1
+    '-i',        -- include headers in output
+  },
+  DEFAULT_EXTRA_CURL_OPTIONS = {},
+  DEFAULT_ERROR_HANDLER = function(_msg) end,
+  DEFAULT_TIMEOUT_HANDLER = function() end,
+}
+
+function CurlRequest:init()
+  assert(self.url, 'missing url')
+
+  self.http_method = self.http_method or self.DEFAULT_HTTP_METHOD
+  self.headers = self.headers or self.DEFAULT_HEADERS
+  self.curl_timeout = self.curl_timeout or self.DEFAULT_CURL_TIMEOUT
+  self.extra_curl_options = self.extra_curl_options or self.DEFAULT_EXTRA_CURL_OPTIONS
+  self.error_handler = self.error_handler or self.DEFAULT_ERROR_HANDLER
+  self.timeout_handler = self.timeout_handler or self.DEFAULT_TIMEOUT_HANDLER
+end
+
+function CurlRequest:execute()
+  local command = table.concat({
+    self.get_curl_cmd(),
+    ' "', self.url, '"',
+    self:extra_curl_arguments(),
+    self:curl_header_arguments(),
+    self:curl_http_method_argument(),
+    self:curl_timeout_argument(),
+  })
+
+  app:debug('CurlRequest: ' .. command)
+
+  local exec_result = (ExecProcess.new { command }):wait()
+
+  if exec_result == nil then
+    local msg = "Unable to run curl"
+    app:log(msg)
+    self.error_handler(msg)
+    return nil
+  end
+
+  local status, output = exec_result:match("(%d+)\n(.*)")
+  status = tonumber(status)
+
+  if status == 28 then
+    app:debug("Curl timeout reached")
+    self.timeout_handler()
+    return nil
+  elseif status ~= 0 then
+    local msg = "Curl failed with status " .. status
+    app:debug(msg)
+    self.error_handler(msg)
+    return nil
+  end
+
+  local response_status, response_body = self.http_status_and_body(output)
+
+  if response_status >= 400 then
+    local msg = "Request failed with status " .. response_status
+    app:log(msg)
+    self.error_handler(msg)
+    return nil
+  end
+
+  local response_json = nil
+  if app:trap(function()
+    response_json = json.decode(response_body)
+  end) then
+    return response_json
+  else
+    app:log("JSON parse error")
+    app:log(output)
+    return nil
+  end
+end
+
+function CurlRequest:curl_header_arguments()
+  local headers = ""
+  for key, value in pairs(self.headers) do
+    headers = headers .. ' -H "' .. key .. ': ' .. value .. '"'
+  end
+
+  return headers
+end
+
+function CurlRequest:extra_curl_arguments()
+  return table.concat(self.BASE_CURL_OPTIONS, ' ')
+    .. ' ' .. table.concat(self.extra_curl_options, ' ')
+end
+
+function CurlRequest:curl_http_method_argument()
+  if self.http_method == 'GET' then
+    return ''
+  end
+
+  return " -X " .. self.http_method
+end
+
+function CurlRequest:curl_timeout_argument()
+  if not self.async or self.curl_timeout == 0 then
+    return ''
+  end
+
+  return ' -m ' .. self.curl_timeout
+end
+
+function CurlRequest.get_curl_cmd()
+  local curl = "curl"
+  if not reaper.GetOS():find("Win") then
+    curl = "/usr/bin/curl"
+  end
+  return curl
+end
+
+function CurlRequest.http_status_and_body(response)
+  local headers, content = CurlRequest._split_curl_response(response)
+  local last_status_line = headers[#headers] and headers[#headers][1] or ''
+
+  local status = last_status_line:match("^HTTP/%d%.%d%s+(%d+)")
+  if not status then
+    return -1, 'Status not found in headers'
+  end
+
+  local body = {}
+  for _, chunk in pairs(content) do
+    table.insert(body, table.concat(chunk, "\n"))
+  end
+
+  return tonumber(status), table.concat(body, "\n")
+end
+
+function CurlRequest._split_curl_response(input)
+  local line_iterator = CurlRequest._line_iterator(input)
+  local chunk_iterator = CurlRequest._chunk_iterator(line_iterator)
+  local header_chunks = {}
+  local content_chunks = {}
+  local in_header = true
+  for chunk in chunk_iterator do
+    if in_header and chunk[1] and chunk[1]:match("^HTTP/%d%.%d") then
+      table.insert(header_chunks, chunk)
+    else
+      in_header = false
+      table.insert(content_chunks, chunk)
+    end
+  end
+  return header_chunks, content_chunks
+end
+
+function CurlRequest._line_iterator(input)
+  if type(input) == 'string' then
+    local i = 1
+    local lines = {}
+    for line in input:gmatch("([^\n]*)\n?") do
+      table.insert(lines, line)
+    end
+    return function ()
+      local line = lines[i]
+      i = i + 1
+      return line
+    end
+  else
+    return input:lines()
+  end
+end
+
+function CurlRequest._chunk_iterator(line_iterator)
+  return function ()
+    local chunk = nil
+    while true do
+      local line = line_iterator()
+      if line == nil or line:match("^%s*$") then break end
+      chunk = chunk or {}
+      table.insert(chunk, line)
+    end
+    return chunk
+  end
+end

--- a/reascripts/ReaSpeech/source/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/CurlRequest.lua
@@ -198,7 +198,7 @@ function CurlRequest:get_url()
     table.insert(query, k .. '=' .. url.quote(v))
   end
 
-  return self.url .. '?' .. table.concat(query, '&')
+  return '"' .. self.url .. '?' .. table.concat(query, '&') .. '"'
 end
 
 function CurlRequest:extra_curl_arguments()

--- a/reascripts/ReaSpeech/source/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/CurlRequest.lua
@@ -79,7 +79,7 @@ function CurlRequest:ready()
   local f = io.open(self.output_file, 'r')
   if not f then
     self.error_msg = "Couldn't open output file: " .. tostring(self.output_file)
-    Tempfile.remove(self.sentinel_file)
+    Tempfile:remove(self.sentinel_file)
     return false
   end
 

--- a/reascripts/ReaSpeech/source/ReaSpeechAPI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechAPI.lua
@@ -22,84 +22,21 @@ function ReaSpeechAPI:get_api_url(remote_path)
   return ("%s/%s"):format(self.base_url, url.quote(remote_path_no_leading_slash))
 end
 
-function ReaSpeechAPI:get_curl_cmd()
-  local curl = "curl"
-  if not reaper.GetOS():find("Win") then
-    curl = "/usr/bin/curl"
-  end
-  return curl
-end
-
 -- Fetch simple JSON responses. Will block until result or curl timeout.
 -- For large amounts of data, use fetch_large instead.
 function ReaSpeechAPI:fetch_json(url_path, http_method, error_handler, timeout_handler)
-  http_method = http_method or 'GET'
-  error_handler = error_handler or function(_msg) end
-  timeout_handler = timeout_handler or function() end
+  local request = CurlRequest.new {
+    url = self:get_api_url(url_path),
+    method = http_method or 'GET',
+    curl_timeout = self.CURL_TIMEOUT_SECONDS,
+    extra_curl_options = {
+      '-s' -- silent mode
+    },
+    error_handler = error_handler or function(_msg) end,
+    timeout_handler = timeout_handler or function() end,
+  }
 
-  local curl = self:get_curl_cmd()
-  local api_url = self:get_api_url(url_path)
-
-  local http_method_argument = ""
-  if http_method ~= 'GET' then
-    http_method_argument = " -X " .. http_method
-  end
-
-  local command = table.concat({
-    curl,
-    ' "', api_url, '"',
-    ' --http1.1',
-    ' -H "accept: application/json"',
-    http_method_argument,
-    ' -m ', self.CURL_TIMEOUT_SECONDS,
-    ' -s',
-    ' -i',
-  })
-
-  app:debug('Fetch JSON: ' .. command)
-
-  local exec_result = (ExecProcess.new { command }):wait()
-
-  if exec_result == nil then
-    local msg = "Unable to run curl"
-    app:log(msg)
-    error_handler(msg)
-    return nil
-  end
-
-  local status, output = exec_result:match("(%d+)\n(.*)")
-  status = tonumber(status)
-
-  if status == 28 then
-    app:debug("Curl timeout reached")
-    timeout_handler()
-    return nil
-  elseif status ~= 0 then
-    local msg = "Curl failed with status " .. status
-    app:debug(msg)
-    error_handler(msg)
-    return nil
-  end
-
-  local response_status, response_body = self.http_status_and_body(output)
-
-  if response_status >= 400 then
-    local msg = "Request failed with status " .. response_status
-    app:log(msg)
-    error_handler(msg)
-    return nil
-  end
-
-  local response_json = nil
-  if app:trap(function()
-    response_json = json.decode(response_body)
-  end) then
-    return response_json
-  else
-    app:log("JSON parse error")
-    app:log(output)
-    return nil
-  end
+  return request:execute()
 end
 
 -- Requests data that may be large or time-consuming.
@@ -108,7 +45,7 @@ end
 function ReaSpeechAPI:fetch_large(url_path, http_method)
   http_method = http_method or 'GET'
 
-  local curl = self:get_curl_cmd()
+  local curl = CurlRequest.get_curl_cmd()
   local api_url = self:get_api_url(url_path)
 
   local http_method_argument = ""
@@ -153,7 +90,7 @@ end
 -- This method is non-blocking, and does not give any indication that it has
 -- completed. The path to the output file is returned.
 function ReaSpeechAPI:post_request(url_path, data, file_path)
-  local curl = self:get_curl_cmd()
+  local curl = CurlRequest.get_curl_cmd()
   local api_url = self:get_api_url(url_path)
 
   local query = {}
@@ -193,69 +130,5 @@ function ReaSpeechAPI:_maybe_quote(arg)
     return arg
   else
     return "'" .. arg .. "'"
-  end
-end
-
-function ReaSpeechAPI.http_status_and_body(response)
-  local headers, content = ReaSpeechAPI._split_curl_response(response)
-  local last_status_line = headers[#headers] and headers[#headers][1] or ''
-
-  local status = last_status_line:match("^HTTP/%d%.%d%s+(%d+)")
-  if not status then
-    return -1, 'Status not found in headers'
-  end
-
-  local body = {}
-  for _, chunk in pairs(content) do
-    table.insert(body, table.concat(chunk, "\n"))
-  end
-
-  return tonumber(status), table.concat(body, "\n")
-end
-
-function ReaSpeechAPI._split_curl_response(input)
-  local line_iterator = ReaSpeechAPI._line_iterator(input)
-  local chunk_iterator = ReaSpeechAPI._chunk_iterator(line_iterator)
-  local header_chunks = {}
-  local content_chunks = {}
-  local in_header = true
-  for chunk in chunk_iterator do
-    if in_header and chunk[1] and chunk[1]:match("^HTTP/%d%.%d") then
-      table.insert(header_chunks, chunk)
-    else
-      in_header = false
-      table.insert(content_chunks, chunk)
-    end
-  end
-  return header_chunks, content_chunks
-end
-
-function ReaSpeechAPI._line_iterator(input)
-  if type(input) == 'string' then
-    local i = 1
-    local lines = {}
-    for line in input:gmatch("([^\n]*)\n?") do
-      table.insert(lines, line)
-    end
-    return function ()
-      local line = lines[i]
-      i = i + 1
-      return line
-    end
-  else
-    return input:lines()
-  end
-end
-
-function ReaSpeechAPI._chunk_iterator(line_iterator)
-  return function ()
-    local chunk = nil
-    while true do
-      local line = line_iterator()
-      if line == nil or line:match("^%s*$") then break end
-      chunk = chunk or {}
-      table.insert(chunk, line)
-    end
-    return chunk
   end
 end

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -275,7 +275,7 @@ function ReaSpeechWorker:handle_response_json(output_file, sentinel_file, succes
     return
   end
 
-  local http_status, body = ReaSpeechAPI.http_status_and_body(f)
+  local http_status, body = CurlRequest.http_status_and_body(f)
   f:close()
 
   if http_status == -1 then

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -212,7 +212,7 @@ function ReaSpeechWorker:start_active_job()
   end
 
   local active_job = self.active_job
-  active_job.request = ReaSpeechAPI:post_request(
+  active_job.initial_request = ReaSpeechAPI:post_request(
     active_job.endpoint, active_job.data, active_job.job.path)
 end
 
@@ -221,12 +221,12 @@ function ReaSpeechWorker:check_active_job()
 
   local active_job = self.active_job
 
-  if active_job.request then
-    self:check_active_job_request_output_file()
+  if active_job.initial_request then
+    self:check_active_job_request_status()
   end
 
   if active_job.transcript_request then
-    self:check_active_job_transcript_output_file()
+    self:check_active_job_transcript_request_status()
   else
     self:check_active_job_status()
   end
@@ -246,9 +246,9 @@ function ReaSpeechWorker:check_active_job_status()
   end
 end
 
-function ReaSpeechWorker:check_active_job_request_output_file()
+function ReaSpeechWorker:check_active_job_request_status()
   local active_job = self.active_job
-  local request = active_job.request
+  local request = active_job.initial_request
 
   if request:ready() then
     if self:handle_job_status(active_job, request:result()) then
@@ -260,7 +260,7 @@ function ReaSpeechWorker:check_active_job_request_output_file()
   end
 end
 
-function ReaSpeechWorker:check_active_job_transcript_output_file()
+function ReaSpeechWorker:check_active_job_transcript_request_status()
   local active_job = self.active_job
   local request = active_job.transcript_request
 

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -77,8 +77,11 @@ function ReaSpeechWorker:progress()
   -- the active job adds 1 to the total count, and if we can know the progress
   -- then we can use that fraction
   if self.active_job then
-    if self.active_job.job and self.active_job.job.progress then
-      local progress = self.active_job.job.progress
+    local active_job = self.active_job
+    if active_job.initial_request and not active_job.initial_request:ready() then
+      active_job_progress = active_job.initial_request:progress() / 100
+    elseif active_job.job and active_job.job.progress then
+      local progress = active_job.job.progress
       active_job_progress = (progress.current / progress.total)
     end
 
@@ -90,8 +93,13 @@ function ReaSpeechWorker:progress()
 end
 
 function ReaSpeechWorker:status()
-  if self.active_job and self.active_job.job then
-    return self.active_job.job.job_status
+  if self.active_job then
+    local active_job = self.active_job
+    if active_job.initial_request and not active_job.initial_request:ready() then
+      return 'Uploading'
+    elseif active_job.job then
+      return active_job.job.job_status
+    end
   end
 end
 

--- a/reascripts/common/.luacheckrc
+++ b/reascripts/common/.luacheckrc
@@ -1,4 +1,5 @@
 globals = {
+  "table"
 }
 
 allow_defined = true

--- a/reascripts/common/libs/TableUtils.lua
+++ b/reascripts/common/libs/TableUtils.lua
@@ -1,0 +1,19 @@
+--[[
+
+  TableUtils.lua - miscellaneous table utilities
+
+]]--
+
+table.flatten = table.flatten or function(tables)
+  local result = {}
+
+  for _, t in ipairs(tables or {}) do
+    if type(t) == 'table' then
+      for _, u in ipairs(t) do
+        table.insert(result, u)
+      end
+    end
+  end
+
+  return result
+end

--- a/reascripts/common/tests/TestTableUtils.lua
+++ b/reascripts/common/tests/TestTableUtils.lua
@@ -1,0 +1,28 @@
+package.path = '../common/libs/?.lua;../common/vendor/?.lua;' .. package.path
+
+local lu = require('luaunit')
+
+require('TableUtils')
+
+--
+
+TestTableUtils = {}
+
+function TestTableUtils:testFlattenMethodExists()
+  lu.assertNotNil(table['flatten'])
+  lu.assertEquals(type(table['flatten']), 'function')
+end
+
+function TestTableUtils:testFlatten()
+  local tables = {
+    {1, 2, 3},
+    {4, 5, 6},
+    {7, 8, 9},
+  }
+
+  local result = table.flatten(tables)
+
+  lu.assertEquals(result, {1, 2, 3, 4, 5, 6, 7, 8, 9})
+end
+
+os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
after a few false starts, i've finally got a functional `CurlRequest` that hides a lot of the messy stuff involved with that backend interaction paradigm. `ReaSpeechAPI` is now mostly just wrappers around `CurlRequest` functions. sync+async calls are supported - the latter is instantiated via the `async` factory that pops a few extra bits of state around whatever other options would be passed into the request (stuff like the output and sentinel files).

basic interface (see `CurlRequest:init()` for available options):
  - (sync, successfull call) `CurlRequest.new(options):execute()` -> `<server response>`
  - (sync, failed call) `CurlRequest.new(options):execute()` -> `nil`, fail/timeout errors specified in options are called as applicable
  - (async) `CurlRequest.async(options):execute()` -> `<request object>`
    - `request:ready()` -> `true` when request is complete and response is stored
    - `request:result()` -> `<response text>`
    - `request:error()` -> `<error message, if applicable>`

~future goal with this is to track upload/download progress to feed the progress bar during transfers (ideal for the potentially long uploads to remote backends). decided to not apply that work here in order to just focus on getting this bit stabilized and ready.~ wiring this up actually felt pretty accessible given the changes on this branch and fix to the sentinel file stuff so...yeah.