### PR TITLE
Generic Logging

### DIFF
--- a/reascripts/ReaSpeech/source/Logging.lua
+++ b/reascripts/ReaSpeech/source/Logging.lua
@@ -58,7 +58,7 @@ function Logging.make_log_entry(prefix, msg, is_debug)
   local log_level = is_debug and "DBG" or "LOG"
   local time = Logging.log_time()
 
-  local log_entry = ("[%s %s, %s] %s"):format(time, prefix, log_level, msg)
+  local log_entry = ("%s [%s, %s] %s"):format(time, prefix, log_level, msg)
   table.insert(Logging.logs, { log_entry, is_debug })
 end
 

--- a/reascripts/ReaSpeech/source/Logging.lua
+++ b/reascripts/ReaSpeech/source/Logging.lua
@@ -6,11 +6,18 @@
 ]]--
 
 Logging = {
+  LOG_LEVEL_LOG = false,
+  LOG_LEVEL_DEBUG = true,
+
+  logs = {},
+
   _loggers = {
-    log = function()
+    log = function(prefix, msg)
+      Logging.make_log_entry(prefix, msg, Logging.LOG_LEVEL_LOG)
     end,
 
-    debug = function()
+    debug = function(prefix, msg)
+      Logging.make_log_entry(prefix, msg, Logging.LOG_LEVEL_DEBUG)
     end
   }
 }
@@ -23,4 +30,16 @@ function Logging.init(target, prefix)
   function target:debug(msg)
     Logging._loggers.debug(prefix, msg)
   end
+end
+
+function Logging.make_log_entry(prefix, msg, is_debug)
+  local log_level = is_debug and "DBG" or "LOG"
+  local time = Logging.log_time()
+
+  local log_entry = ("[%s %s, %s] %s"):format(time, prefix, log_level, msg)
+  table.insert(Logging.logs, { log_entry, is_debug })
+end
+
+function Logging.log_time()
+  return os.date("%Y-%m-%d %H:%M:%S")
 end

--- a/reascripts/ReaSpeech/source/Logging.lua
+++ b/reascripts/ReaSpeech/source/Logging.lua
@@ -1,0 +1,26 @@
+--[[
+
+  Logging.lua - Utilities for generic logging across classes
+                (or anything else that's table based, really)
+
+]]--
+
+Logging = {
+  _loggers = {
+    log = function()
+    end,
+
+    debug = function()
+    end
+  }
+}
+
+function Logging.init(target, prefix)
+  function target:log(msg)
+    Logging._loggers.log(prefix, msg)
+  end
+
+  function target:debug(msg)
+    Logging._loggers.debug(prefix, msg)
+  end
+end

--- a/reascripts/ReaSpeech/source/Logging.lua
+++ b/reascripts/ReaSpeech/source/Logging.lua
@@ -67,5 +67,7 @@ function Logging.log_time()
 end
 
 function Logging:reset()
-  self.logs = {}
+  if #self.logs > 0 then
+    self.logs = {}
+  end
 end

--- a/reascripts/ReaSpeech/source/Logging.lua
+++ b/reascripts/ReaSpeech/source/Logging.lua
@@ -9,6 +9,9 @@ Logging = {
   LOG_LEVEL_LOG = false,
   LOG_LEVEL_DEBUG = true,
 
+  show_logs = false,
+  show_debug_logs = false,
+
   logs = {},
 
   _loggers = {
@@ -21,6 +24,25 @@ Logging = {
     end
   }
 }
+
+function Logging:react()
+  if not self.show_logs then
+    self:reset()
+    return
+  end
+
+  for _, log in pairs(self.logs) do
+    local msg, dbg = table.unpack(log)
+
+    if dbg and self.show_debug_logs then
+      reaper.ShowConsoleMsg(msg .. '\n')
+    elseif not dbg then
+      reaper.ShowConsoleMsg(msg .. '\n')
+    end
+  end
+
+  self:reset()
+end
 
 function Logging.init(target, prefix)
   function target:log(msg)
@@ -42,4 +64,8 @@ end
 
 function Logging.log_time()
   return os.date("%Y-%m-%d %H:%M:%S")
+end
+
+function Logging:reset()
+  self.logs = {}
 end

--- a/reascripts/ReaSpeech/source/ReaSpeechControlsUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechControlsUI.lua
@@ -32,8 +32,13 @@ function ReaSpeechControlsUI:init()
     }
   }
 
-  self.log_enable = ReaSpeechCheckbox.simple(false, 'Enable')
-  self.log_debug = ReaSpeechCheckbox.simple(false, 'Debug')
+  self.log_enable = ReaSpeechCheckbox.simple(false, 'Enable', function(current)
+    Logging.show_logs = current
+  end)
+
+  self.log_debug = ReaSpeechCheckbox.simple(false, 'Debug', function(current)
+    Logging.show_debug_logs = current
+  end)
 
   self.language = ReaSpeechCombo.new {
     default = self.DEFAULT_LANGUAGE,

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -133,6 +133,8 @@ function ReaSpeechUI:react_to_worker_response()
 end
 
 function ReaSpeechUI:react_to_logging()
+  Logging:react()
+
   for _, log in pairs(self.logs) do
     local msg, dbg = table.unpack(log)
     if dbg and self.controls_ui.log_enable:value() and self.controls_ui.log_debug:value() then

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -42,6 +42,7 @@ ReaSpeechCheckbox.new = function (options)
     label_long = nil,
     label_short = nil,
     width_threshold = nil,
+    changed_handler = function() end,
   }
 
   local o = ReaSpeechWidget.new({
@@ -56,12 +57,13 @@ ReaSpeechCheckbox.new = function (options)
   return o
 end
 
-ReaSpeechCheckbox.simple = function(default_value, label)
+ReaSpeechCheckbox.simple = function(default_value, label, changed_handler)
   return ReaSpeechCheckbox.new {
     default = default_value,
     label_long = label,
     label_short = label,
-    width_threshold = 0
+    width_threshold = 0,
+    changed_handler = changed_handler or function() end,
   }
 end
 
@@ -77,6 +79,7 @@ ReaSpeechCheckbox.renderer = function (self, column)
 
   if rv then
     self:set(value)
+    options.changed_handler(value)
   end
 end
 

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -42,8 +42,9 @@ ReaSpeechCheckbox.new = function (options)
     label_long = nil,
     label_short = nil,
     width_threshold = nil,
-    changed_handler = function() end,
   }
+
+  options.changed_handler = options.changed_handler or function() end
 
   local o = ReaSpeechWidget.new({
     default = options.default,
@@ -53,6 +54,7 @@ ReaSpeechCheckbox.new = function (options)
   })
 
   o._value = o.default
+  options.changed_handler(o.default)
 
   return o
 end

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -9,7 +9,6 @@ ReaSpeechWorker = Polo {}
 function ReaSpeechWorker:init()
   assert(self.requests, 'missing requests')
   assert(self.responses, 'missing responses')
-  assert(self.logs, 'missing logs')
 
   Logging.init(self, 'ReaSpeechWorker')
 

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -11,6 +11,8 @@ function ReaSpeechWorker:init()
   assert(self.responses, 'missing responses')
   assert(self.logs, 'missing logs')
 
+  Logging.init(self, 'ReaSpeechWorker')
+
   self.active_job = nil
   self.pending_jobs = {}
   self.job_count = 0
@@ -59,7 +61,7 @@ function ReaSpeechWorker:react_handle_jobs()
     self.active_job = pending_job
     self:start_active_job()
   elseif self.job_count ~= 0 then
-    app:log('Processing finished')
+    self:log('Processing finished')
     self.job_count = 0
   end
 end
@@ -137,7 +139,7 @@ function ReaSpeechWorker:get_job_status(job_id)
 end
 
 function ReaSpeechWorker:handle_request(request)
-  app:log('Processing speech...')
+  self:log('Processing speech...')
   self.job_count = #request.jobs
 
   local data = {
@@ -177,8 +179,8 @@ end
 
 -- May return true if the job has completed and should no longer be active
 function ReaSpeechWorker:handle_job_status(active_job, response)
-  app:debug('Active job: ' .. dump(active_job))
-  app:debug('Status: ' .. dump(response))
+  self:debug('Active job: ' .. dump(active_job))
+  self:debug('Status: ' .. dump(response))
 
   if response.error then
     table.insert(self.responses, { error = response.error })

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -16,6 +16,9 @@ TranscriptExporter = Polo {
 
 function TranscriptExporter:init()
   assert(self.transcript, 'missing transcript')
+
+  Logging.init(self, 'TranscriptExporter')
+
   self.is_open = false
   self.export_formats = TranscriptExporterFormats.new {
     TranscriptExportFormat.exporter_json(),
@@ -210,7 +213,7 @@ end
 function TranscriptExporterFormats:selected_format()
   if not self.selected_format_key then
     if not self.formatters or #self.formatters < 1 then
-      app:debug('no formats to set for default')
+      self:debug('no formats to set for default')
       return
     end
 

--- a/reascripts/ReaSpeech/tests/TestLogging.lua
+++ b/reascripts/ReaSpeech/tests/TestLogging.lua
@@ -12,6 +12,90 @@ TestLogging = {}
 function TestLogging:setUp()
 end
 
+function TestLogging:testLogMethod()
+  local prefix = "TestLoggingClass prefix"
+  local test_class = Polo {
+    init = function(self)
+      Logging.init(self, prefix)
+    end
+  }
+
+  Logging.log_time = function()
+    return "<time>"
+  end
+
+  Logging.logs = {}
+
+  local log_message1 = "This is a log message"
+  local log_message2 = "This is another log message"
+
+  local instance = test_class.new()
+  instance:log(log_message1)
+  instance:log(log_message2)
+
+  lu.assertEquals(Logging.logs, {
+    { ("[<time> %s, LOG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_LOG },
+    { ("[<time> %s, LOG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_LOG },
+  })
+end
+
+function TestLogging:testDebugMethod()
+  local prefix = "TestLoggingClass prefix"
+  local test_class = Polo {
+    init = function(self)
+      Logging.init(self, prefix)
+    end
+  }
+
+  Logging.log_time = function()
+    return "<time>"
+  end
+
+  Logging.logs = {}
+
+  local log_message1 = "This is a log message"
+  local log_message2 = "This is another log message"
+
+  local instance = test_class.new()
+  instance:debug(log_message1)
+  instance:debug(log_message2)
+
+  lu.assertEquals(Logging.logs, {
+    { ("[<time> %s, DBG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_DEBUG },
+    { ("[<time> %s, DBG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_DEBUG },
+  })
+end
+
+function TestLogging:testMixedCalls()
+  local prefix = "TestLoggingClass prefix"
+  local test_class = Polo {
+    init = function(self)
+      Logging.init(self, prefix)
+    end
+  }
+
+  Logging.log_time = function()
+    return "<time>"
+  end
+
+  Logging.logs = {}
+
+  local log_message1 = "This is a log message"
+  local log_message2 = "This is another log message"
+  local log_message3 = "This is the third log message"
+
+  local instance = test_class.new()
+  instance:log(log_message1)
+  instance:debug(log_message2)
+  instance:log(log_message3)
+
+  lu.assertEquals(Logging.logs, {
+    { ("[<time> %s, LOG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_LOG },
+    { ("[<time> %s, DBG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_DEBUG },
+    { ("[<time> %s, LOG] %s"):format(prefix, log_message3), Logging.LOG_LEVEL_LOG },
+  })
+end
+
 function TestLogging:testPatchedLogMethod()
   local test_class = Polo {
     init = function(self)

--- a/reascripts/ReaSpeech/tests/TestLogging.lua
+++ b/reascripts/ReaSpeech/tests/TestLogging.lua
@@ -2,8 +2,9 @@ package.path = '../common/libs/?.lua;../common/vendor/?.lua;' .. package.path
 
 local lu = require('luaunit')
 
-require('source/Logging')
+require('mock_reaper')
 require('Polo')
+require('source/Logging')
 
 --
 
@@ -96,6 +97,14 @@ function TestLogging:testMixedCalls()
   })
 end
 
+function TestLogging:testReset()
+  Logging.logs = { "This is a log message", "This is another log message" }
+
+  Logging:reset()
+
+  lu.assertEquals(#Logging.logs, 0)
+end
+
 function TestLogging:testPatchedLogMethod()
   local test_class = Polo {
     init = function(self)
@@ -134,6 +143,91 @@ function TestLogging:testPatchedDebugMethod()
 
   local instance = test_class.new()
   instance:debug(debug_message)
+end
+
+function TestLogging:testReactRespectsShowLogsOff()
+  Logging.show_logs = false
+  Logging.logs = {
+    { "This is a log message", Logging.LOG_LEVEL_LOG },
+    { "This is a debug message", Logging.LOG_LEVEL_DEBUG },
+  }
+
+  local yay_no_calls = true
+
+  reaper.ShowConsoleMsg = function(msg)
+      yay_no_calls = false
+  end
+
+  Logging:react()
+
+  lu.assertEquals(yay_no_calls, true)
+  lu.assertEquals(Logging.logs, {})
+end
+
+function TestLogging:testReactRespectsShowLogsOn()
+  Logging.show_logs = true
+  Logging.show_debug_logs = false
+
+  Logging.logs = {
+    { "This is a log message", Logging.LOG_LEVEL_LOG },
+    { "This is a debug message", Logging.LOG_LEVEL_DEBUG },
+  }
+
+  local happy_call = false
+  reaper.ShowConsoleMsg = function(msg)
+    if msg:match("This is a log message\n") then
+      happy_call = true
+    end
+
+    if msg:match("This is a debug message\n") then
+      lu.fail("I didn't want debug messages!")
+    end
+  end
+
+  Logging:react()
+
+  lu.assertEquals(happy_call, true)
+  lu.assertEquals(Logging.logs, {})
+end
+
+function TestLogging:testReactRespectsShowDebugLogsOn()
+  Logging.show_logs = true
+  Logging.show_debug_logs = true
+  Logging.logs = {
+    { "This is a log message", Logging.LOG_LEVEL_LOG },
+    { "This is a debug message", Logging.LOG_LEVEL_DEBUG },
+  }
+
+  local happy_calls = 0
+
+  reaper.ShowConsoleMsg = function(msg)
+    happy_calls = happy_calls + 1
+  end
+
+  Logging:react()
+
+  lu.assertEquals(happy_calls, 2)
+  lu.assertEquals(Logging.logs, {})
+end
+
+function TestLogging:testReactIgnoresShowDebugLogsIfShowLogsOff()
+  Logging.show_logs = false
+  Logging.show_debug_logs = true
+  Logging.logs = {
+    { "This is a log message", Logging.LOG_LEVEL_LOG },
+    { "This is a debug message", Logging.LOG_LEVEL_DEBUG },
+  }
+
+  local sad_calls = 0
+
+  reaper.ShowConsoleMsg = function(msg)
+    sad_calls = sad_calls + 1
+  end
+
+  Logging:react()
+
+  lu.assertEquals(sad_calls, 0)
+  lu.assertEquals(Logging.logs, {})
 end
 
 --

--- a/reascripts/ReaSpeech/tests/TestLogging.lua
+++ b/reascripts/ReaSpeech/tests/TestLogging.lua
@@ -1,0 +1,57 @@
+package.path = '../common/libs/?.lua;../common/vendor/?.lua;' .. package.path
+
+local lu = require('luaunit')
+
+require('source/Logging')
+require('Polo')
+
+--
+
+TestLogging = {}
+
+function TestLogging:setUp()
+end
+
+function TestLogging:testPatchedLogMethod()
+  local test_class = Polo {
+    init = function(self)
+      Logging.init(self, "TestLoggingClass prefix")
+    end
+  }
+
+  local log_message = "This is a log message"
+
+  Logging._loggers = {
+    log = function(prefix, msg)
+      lu.assertEquals(prefix, "TestLoggingClass prefix")
+      lu.assertEquals(msg, log_message)
+    end,
+  }
+
+  local instance = test_class.new()
+  instance:log(log_message)
+end
+
+function TestLogging:testPatchedDebugMethod()
+  local test_class = Polo {
+    init = function(self)
+      Logging.init(self, "TestLoggingClass prefix")
+    end
+  }
+
+  local debug_message = "This is a debug message"
+
+  Logging._loggers = {
+    debug = function(prefix, msg)
+      lu.assertEquals(prefix, "TestLoggingClass prefix")
+      lu.assertEquals(msg, debug_message)
+    end,
+  }
+
+  local instance = test_class.new()
+  instance:debug(debug_message)
+end
+
+--
+
+os.exit(lu.LuaUnit.run())

--- a/reascripts/ReaSpeech/tests/TestLogging.lua
+++ b/reascripts/ReaSpeech/tests/TestLogging.lua
@@ -35,8 +35,8 @@ function TestLogging:testLogMethod()
   instance:log(log_message2)
 
   lu.assertEquals(Logging.logs, {
-    { ("[<time> %s, LOG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_LOG },
-    { ("[<time> %s, LOG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_LOG },
+    { ("<time> [%s, LOG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_LOG },
+    { ("<time> [%s, LOG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_LOG },
   })
 end
 
@@ -62,8 +62,8 @@ function TestLogging:testDebugMethod()
   instance:debug(log_message2)
 
   lu.assertEquals(Logging.logs, {
-    { ("[<time> %s, DBG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_DEBUG },
-    { ("[<time> %s, DBG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_DEBUG },
+    { ("<time> [%s, DBG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_DEBUG },
+    { ("<time> [%s, DBG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_DEBUG },
   })
 end
 
@@ -91,9 +91,9 @@ function TestLogging:testMixedCalls()
   instance:log(log_message3)
 
   lu.assertEquals(Logging.logs, {
-    { ("[<time> %s, LOG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_LOG },
-    { ("[<time> %s, DBG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_DEBUG },
-    { ("[<time> %s, LOG] %s"):format(prefix, log_message3), Logging.LOG_LEVEL_LOG },
+    { ("<time> [%s, LOG] %s"):format(prefix, log_message1), Logging.LOG_LEVEL_LOG },
+    { ("<time> [%s, DBG] %s"):format(prefix, log_message2), Logging.LOG_LEVEL_DEBUG },
+    { ("<time> [%s, LOG] %s"):format(prefix, log_message3), Logging.LOG_LEVEL_LOG },
   })
 end
 

--- a/reascripts/ReaSpeech/tests/TestLogging.lua
+++ b/reascripts/ReaSpeech/tests/TestLogging.lua
@@ -105,6 +105,20 @@ function TestLogging:testReset()
   lu.assertEquals(#Logging.logs, 0)
 end
 
+function TestLogging:testResetReusesEmptyLogsTable()
+  local original_table = Logging.logs
+
+  Logging:reset()
+
+  lu.assertIs(Logging.logs, original_table)
+
+  Logging.logs = {{ "msg", Logging.LOG_LEVEL_LOG }}
+
+  Logging:reset()
+
+  lu.assertNotIs(Logging.logs, original_table)
+end
+
 function TestLogging:testPatchedLogMethod()
   local test_class = Polo {
     init = function(self)

--- a/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
@@ -9,6 +9,7 @@ require('mock_reaper')
 require('source/AlertPopup')
 require('source/ColumnLayout')
 require('source/KeyMap')
+require('source/Logging')
 require('source/ReaSpeechActionsUI')
 require('source/ReaSpeechAPI')
 require('source/ReaSpeechControlsUI')
@@ -37,7 +38,6 @@ end
 function TestReaSpeechUI:testInit()
   lu.assertEquals(#self.app.requests, 0)
   lu.assertEquals(#self.app.responses, 0)
-  lu.assertEquals(#self.app.logs, 0)
 end
 
 --


### PR DESCRIPTION
as discussed in https://github.com/TeamAudio/reaspeech/pull/78#discussion_r1742688265, this adds generic logging capability that can be applied to any of our Lua modules via a call like `Logging.init(self_reference_to_target_object, "Prefix")`.

i aimed to reflect current behavior, but there is one big deviation that comes to mind. the time in the log message will now reflect when the message was generated, not when it's displayed in the console.

modules that referenced `app:log` or `app:debug` have been updated with the new generic logging.