### PR TITLE
Fix job status checks

### DIFF
--- a/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
@@ -14,20 +14,23 @@ function ReaSpeechActionsUI.pluralizer(count, suffix)
   if count == 0 then
     return '', suffix
   elseif count == 1 then
-    return '1', ''
+    return '', ''
   else
-    return '', suffix
+    return count .. ' ', suffix
   end
 end
 
 function ReaSpeechActionsUI:render()
   local disable_if = self.disabler
-  local progress = self.worker:progress()
+  local progress
+  app:trap(function ()
+    progress = self.worker:progress()
+  end)
 
   disable_if(progress, function()
     local selected_track_count = reaper.CountSelectedTracks(ReaUtil.ACTIVE_PROJECT)
     disable_if(selected_track_count == 0, function()
-      local button_text = ("Process %s Selected Track%s")
+      local button_text = ("Process %sSelected Track%s")
         :format(self.pluralizer(selected_track_count, 's'))
 
       if ImGui.Button(ctx, button_text) then
@@ -39,7 +42,7 @@ function ReaSpeechActionsUI:render()
 
     local selected_item_count = reaper.CountSelectedMediaItems(ReaUtil.ACTIVE_PROJECT)
     disable_if(selected_item_count == 0, function()
-      local button_text = ("Process %s Selected Item%s")
+      local button_text = ("Process %sSelected Item%s")
         :format(self.pluralizer(selected_item_count, 's'))
 
       if ImGui.Button(ctx, button_text) then

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -123,6 +123,7 @@ function ReaSpeechWorker:cancel_job(job_id)
 end
 
 function ReaSpeechWorker:format_job_status(job_status)
+  if not job_status then return nil end
   local s = job_status:lower():gsub("_", " ")
   return s:gsub("(%w)(%w*)", function(first, rest)
     return first:upper() .. rest

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -80,7 +80,10 @@ function ReaSpeechWorker:progress()
   if self.active_job then
     local active_job = self.active_job
     if active_job.initial_request and not active_job.initial_request:ready() then
-      active_job_progress = active_job.initial_request:progress() / 100
+      initial_request_progress = active_job.initial_request:progress()
+      if initial_request_progress then
+        active_job_progress = initial_request_progress / 100
+      end
     elseif active_job.job and active_job.job.progress then
       local progress = active_job.job.progress
       active_job_progress = (progress.current / progress.total)

--- a/reascripts/ReaSpeech/source/include/globals.lua
+++ b/reascripts/ReaSpeech/source/include/globals.lua
@@ -13,14 +13,15 @@ end
 
 -- For debugging
 function dump(o)
-  if type(o) == 'table' then
-    local s = '{ '
-    for k,v in pairs(o) do
-      if type(k) ~= 'number' then k = '"'..k..'"' end
-      s = s .. '['..k..'] = ' .. dump(v) .. ','
-    end
-    return s .. '} '
-  else
-    return tostring(o)
+  if type(o) ~= "table" then return tostring(o) end
+  local result = {"{"}
+  for k, v in pairs(o) do
+    k = type(k) == "string" and k or "[" .. dump(k) .. "]"
+    v = type(v) == "string" and '"' .. v .. '"' or dump(v)
+    table.insert(result, k .. " = " .. v .. ",")
   end
+  if #result == 1 then return "{}" end
+  result[#result] = result[#result]:gsub(",$", "")
+  table.insert(result, "}")
+  return table.concat(result, " ")
 end


### PR DESCRIPTION
One reason for the flickery screen updates during processing is that errors when checking job status were uncaught, causing intermittent lack of rendering of the actions and transcript portions of the UI. An example of such an error is "[CurlRequest, LOG] Unable to open progress file". Another cause was an error when attempting to format a nil job status. This change improves error handling. There still is a bit of flicker as the progress bar gets reused for various purposes, but it's less jumpy now that large portions of the UI remain visible.

This also adds an improved dump function which has nicer output in my eyes, and eliminates extra trailing commas.