### PR TITLE
Support older versions of curl with respect to sentinel files

### DIFF
--- a/reascripts/ReaSpeech/source/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/CurlRequest.lua
@@ -262,8 +262,13 @@ function CurlRequest.get_curl_cmd()
 end
 
 function CurlRequest.supports_sentinel()
+  -- Sentinel depends on --write-out %output{filename} feature,
+  -- which requires curl 8.3.0 or newer
   local version = CurlRequest.curl_version()
-  return version[1] == 8 and version[2] >= 3
+  if version[1] and version[1] > 7 then
+    return version[1] > 8 or version[2] >= 3
+  end
+  return false
 end
 
 function CurlRequest:get_url()

--- a/reascripts/ReaSpeech/source/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/CurlRequest.lua
@@ -318,6 +318,11 @@ function CurlRequest:check_sentinel()
 
   local contents = sentinel:read("*all")
   sentinel:close()
+
+  -- Workaround for https://github.com/curl/curl/issues/10491
+  local version = CurlRequest.curl_version()
+  if version and version[1] < 8 then return true end
+
   self:debug('Checking sentinel: ' .. contents)
   return contents and contents:find(CurlRequest.SENTINEL)
 end

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -107,7 +107,7 @@ function ReaSpeechUI:react_to_worker_response()
     return
   end
 
-  self:debug('Response: ' .. dump(response))
+  -- self:debug('Response: ' .. dump(response))
 
   if response.error then
     self.failure:show(response.error)


### PR DESCRIPTION
The `--write-out %output{filename}` feature only works with curl 8.3.0 or newer. ReaSpeech currently gets stuck with older versions of curl because the lack of this feature means the sentinel file never gets written. This affects Linux Mint, which comes with curl 7.81.0.

Detect the curl version and conditionally support the sentinel file if curl is new enough. Otherwise, fall back on checking for the existence of the progress file (curl's stderr destination). This means that an async curl process may be considered "ready" even though it is still executing, so the error handling is not as robust in that case.