### PR TITLE
Add storage library

### DIFF
--- a/reascripts/common/libs/Storage.lua
+++ b/reascripts/common/libs/Storage.lua
@@ -1,0 +1,251 @@
+--[[
+
+  Storage.lua - Persistence helper for configuration data
+
+  ExtState Example:
+
+    local settings = Storage.ExtState.make {
+      section = 'MyScript.Settings',
+      persist = true,
+    }
+
+    local my_setting = settings:boolean('my_setting', true)
+    local my_number = settings:number('my_number', 42)
+    local my_string = settings:string('my_string', 'hello')
+
+    local my_setting_value = my_setting:get()
+    my_setting:set(not my_setting_value)
+    my_setting:erase()
+
+    local my_number_value = my_number:get()
+    my_number:set(my_number_value + 1)
+
+    local my_string_value = my_string:get()
+    my_string:set(my_string_value .. ' world')
+
+  ProjExtState Example:
+
+    local proj_storage = Storage.ProjExtState.make {
+      project = 0,
+      extname = 'MyExtension',
+    }
+
+    local my_proj_setting = proj_settings:boolean('my_proj_setting', true)
+    local my_proj_number = proj_settings:number('my_proj_number', 42)
+    local my_proj_string = proj_settings:string('my_proj_string', 'hello')
+
+    local my_proj_setting_value = my_proj_setting:get()
+    my_proj_setting:set(not my_proj_setting_value)
+    my_proj_setting:erase()
+
+    local my_proj_number_value = my_proj_number:get()
+    my_proj_number:set(my_proj_number_value + 1)
+
+    local my_proj_string_value = my_proj_string:get()
+    my_proj_string:set(my_proj_string_value .. ' world')
+
+  API:
+
+    Storage.ExtState.make(options)
+      Create a new ExtState storage object.
+
+      options:
+        section (string) - The section name for the ExtState data.
+        persist (boolean) - Whether the data should persist between sessions.
+
+    Storage.ProjExtState.make(options)
+      Create a new ProjExtState storage object.
+
+      options:
+        project (integer) - The project identifier.
+        extname (string) - The extension name for the ProjExtState data.
+
+    storage:boolean(key, default)
+      Create a boolean storage cell.
+
+      key (string) - The key for the storage data.
+      default (boolean) - The default value for the storage data.
+
+    storage:number(key, default)
+      Create a number storage cell.
+
+      key (string) - The key for the storage data.
+      default (number) - The default value for the storage data.
+
+    storage:string(key, default)
+      Create a string storage cell.
+
+      key (string) - The key for the storage data.
+      default (string) - The default value for the storage data.
+
+    cell:get()
+      Get the value of the storage cell.
+
+    cell:set(value)
+      Set the value of the storage cell.
+
+    cell:erase()
+      Erase the storage data.
+
+]]--
+
+Storage = {
+  new = function (engine)
+    local o = { engine = engine }
+    setmetatable(o, Storage)
+    return o
+  end,
+}
+Storage.__index = Storage
+
+function Storage:boolean(key, default)
+  local engine = self.engine
+  return Storage.Cell.new {
+    get = function () return engine.get_boolean(key, default) end,
+    set = function (value) engine.set_boolean(key, value) end,
+    erase = function () engine.erase(key) end,
+  }
+end
+
+function Storage:number(key, default)
+  local engine = self.engine
+  return Storage.Cell.new {
+    get = function () return engine.get_number(key, default) end,
+    set = function (value) engine.set_number(key, value) end,
+    erase = function () engine.erase(key) end,
+  }
+end
+
+function Storage:string(key, default)
+  local engine = self.engine
+  return Storage.Cell.new {
+    get = function () return engine.get_string(key, default) end,
+    set = function (value) engine.set_string(key, value) end,
+    erase = function () engine.erase(key) end,
+  }
+end
+
+function Storage._boolean_to_string(bool)
+  return bool and 'true' or 'false'
+end
+
+function Storage._number_to_string(num)
+  return tostring(tonumber(num) or 0)
+end
+
+function Storage._string_to_boolean(str)
+  return str ~= 'false'
+end
+
+function Storage._string_to_number(str)
+  return tonumber(str) or 0
+end
+
+Storage.Cell = {
+  new = function (methods)
+    local o = {}
+
+    if methods.get then
+      function o:get(key)
+        return methods.get(key)
+      end
+    end
+
+    if methods.set then
+      function o:set(value)
+        return methods.set(value)
+      end
+    end
+
+    if methods.erase then
+      function o:erase()
+        return methods.erase()
+      end
+    end
+
+    setmetatable(o, Storage.Cell)
+
+    return o
+  end
+}
+Storage.Cell.__index = Storage.Cell
+
+Storage.ExtState = {
+  make = function (options)
+    assert(options.section, 'missing section')
+
+    local section = options.section
+    local persist = options.persist or false
+
+    local exists = function (key)
+      return reaper.HasExtState(section, key)
+    end
+
+    return Storage.new {
+      get_boolean = function (key, default)
+        if not exists(key) then return default end
+        return Storage._string_to_boolean(reaper.GetExtState(section, key))
+      end,
+      get_number = function (key, default)
+        if not exists(key) then return default end
+        return Storage._string_to_number(reaper.GetExtState(section, key))
+      end,
+      get_string = function (key, default)
+        if not exists(key) then return default end
+        return reaper.GetExtState(section, key)
+      end,
+      set_boolean = function (key, value)
+        reaper.SetExtState(section, key, Storage._boolean_to_string(value), persist)
+      end,
+      set_number = function (key, value)
+        reaper.SetExtState(section, key, Storage._number_to_string(value), persist)
+      end,
+      set_string = function (key, value)
+        reaper.SetExtState(section, key, tostring(value), persist)
+      end,
+      erase = function (key)
+        reaper.DeleteExtState(section, key, persist)
+      end,
+    }
+  end,
+}
+
+Storage.ProjExtState = {
+  make = function (options)
+    assert(options.project, 'missing project')
+    assert(options.extname, 'missing extname')
+
+    local project = options.project
+    local extname = options.extname
+
+    return Storage.new {
+      get_boolean = function (key, default)
+        local rv, value = reaper.GetProjExtState(project, extname, key)
+        if rv == 0 then return default end
+        return Storage._string_to_boolean(value)
+      end,
+      get_number = function (key, default)
+        local rv, value = reaper.GetProjExtState(project, extname, key)
+        if rv == 0 then return default end
+        return Storage._string_to_number(value)
+      end,
+      get_string = function (key, default)
+        local rv, value = reaper.GetProjExtState(project, extname, key)
+        if rv == 0 then return default end
+        return value
+      end,
+      set_boolean = function (key, value)
+        reaper.SetProjExtState(project, extname, key, Storage._boolean_to_string(value))
+      end,
+      set_number = function (key, value)
+        reaper.SetProjExtState(project, extname, key, Storage._number_to_string(value))
+      end,
+      set_string = function (key, value)
+        reaper.SetProjExtState(project, extname, key, tostring(value))
+      end,
+      erase = function (key)
+        reaper.SetProjExtState(project, extname, key, '')
+      end,
+    }
+  end,
+}

--- a/reascripts/common/libs/Storage.lua
+++ b/reascripts/common/libs/Storage.lua
@@ -134,7 +134,7 @@ function Storage._number_to_string(num)
 end
 
 function Storage._string_to_boolean(str)
-  return str ~= 'false'
+  return str == 'true'
 end
 
 function Storage._string_to_number(str)

--- a/reascripts/common/libs/mock_reaper.lua
+++ b/reascripts/common/libs/mock_reaper.lua
@@ -1,8 +1,10 @@
 reaper = reaper or {
   __ext_state__ = {},
+  __proj_ext_state__ = {},
 
   __test_setUp = function ()
     reaper.__ext_state__ = {}
+    reaper.__proj_ext_state__ = {}
   end,
 
   APIExists = function (_)
@@ -34,6 +36,26 @@ reaper = reaper or {
     if reaper.__ext_state__[section] then
       reaper.__ext_state__[section][key] = nil
     end
+  end,
+
+  GetProjExtState = function (proj, extname, key)
+    if (reaper.__proj_ext_state__[proj]
+        and reaper.__proj_ext_state__[proj][extname]
+        and reaper.__proj_ext_state__[proj][extname][key]
+        and reaper.__proj_ext_state__[proj][extname][key] ~= "") then
+      return 1, reaper.__proj_ext_state__[proj][extname][key]
+    end
+    return 0, ""
+  end,
+
+  SetProjExtState = function (proj, extname, key, value)
+    if not reaper.__proj_ext_state__[proj] then
+      reaper.__proj_ext_state__[proj] = {}
+    end
+    if not reaper.__proj_ext_state__[proj][extname] then
+      reaper.__proj_ext_state__[proj][extname] = {}
+    end
+    reaper.__proj_ext_state__[proj][extname][key] = value
   end,
 
   genGuid = function()

--- a/reascripts/common/tests/TestStorage.lua
+++ b/reascripts/common/tests/TestStorage.lua
@@ -1,0 +1,98 @@
+package.path = '../common/libs/?.lua;../common/vendor/?.lua;' .. package.path
+
+local lu = require('luaunit')
+
+require('Storage')
+
+require('mock_reaper')
+
+--
+
+TestStorage = {}
+
+function TestStorage:setUp()
+  reaper.__test_setUp()
+end
+
+function TestStorage:testExtState()
+  local settings = Storage.ExtState.make {
+    section = 'MyScript.Settings',
+    persist = true,
+  }
+
+  local my_setting = settings:boolean('my_setting', true)
+  local my_number = settings:number('my_number', 42)
+  local my_string = settings:string('my_string', 'hello')
+
+  local my_setting_value = my_setting:get()
+  lu.assertEquals(my_setting_value, true)
+  my_setting:set(not my_setting_value)
+  lu.assertEquals(my_setting:get(), false)
+  my_setting:erase()
+  lu.assertEquals(my_setting:get(), true)
+
+  local my_number_value = my_number:get()
+  lu.assertEquals(my_number_value, 42)
+  my_number:set(my_number_value + 1)
+  lu.assertEquals(my_number:get(), 43)
+  my_number:erase()
+  lu.assertEquals(my_number:get(), 42)
+
+  local my_string_value = my_string:get()
+  my_string:set(my_string_value .. ' world')
+  lu.assertEquals(my_string:get(), 'hello world')
+  my_string:erase()
+  lu.assertEquals(my_string:get(), 'hello')
+end
+
+function TestStorage:testProjExtState()
+  local settings = Storage.ProjExtState.make {
+    project = 0,
+    extname = 'MyExtension',
+  }
+
+  local my_setting = settings:boolean('my_setting', true)
+  local my_number = settings:number('my_number', 42)
+  local my_string = settings:string('my_string', 'hello')
+
+  local my_setting_value = my_setting:get()
+  lu.assertEquals(my_setting_value, true)
+  my_setting:set(not my_setting_value)
+  lu.assertEquals(my_setting:get(), false)
+  my_setting:erase()
+  lu.assertEquals(my_setting:get(), true)
+
+  local my_number_value = my_number:get()
+  lu.assertEquals(my_number_value, 42)
+  my_number:set(my_number_value + 1)
+  lu.assertEquals(my_number:get(), 43)
+  my_number:erase()
+  lu.assertEquals(my_number:get(), 42)
+
+  local my_string_value = my_string:get()
+  my_string:set(my_string_value .. ' world')
+  lu.assertEquals(my_string:get(), 'hello world')
+  my_string:erase()
+  lu.assertEquals(my_string:get(), 'hello')
+end
+
+function TestStorage:testDerivedCell()
+  local settings = Storage.ExtState.make {
+    section = 'MyScript.Settings',
+  }
+
+  local my_setting = settings:string('my_setting', '')
+
+  local my_derived_setting = Storage.Cell.new {
+    get = function () return my_setting:get():upper() end,
+  }
+
+  lu.assertEquals(my_derived_setting:get(), '')
+  my_setting:set('test')
+  lu.assertEquals(my_derived_setting:get(), 'TEST')
+
+  lu.assertNil(my_derived_setting.set)
+  lu.assertNil(my_derived_setting.erase)
+end
+
+os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
This change adds a reusable common library for persisting configuration data to ExtState or ProjExtState. It is a rewrite of an internal class we called OptionsConfig, with a design partially inspired by the "Atom" concept (here called a "Cell") from the React community.

Features:

- Supports ExtState (persistent or not) and ProjExtState, and can be extended with additional storage engines
- Automatic type conversion (strings, booleans, and numbers) and built-in default handling to make usage less error-prone
- Enables writing derived cells that can perform additional computation on reads and/or writes

The initial intended purpose of this library is to facilitate adding persistence to ReaSpeech settings.