### PR TITLE
Add persistence for ASR controls

### DIFF
--- a/reascripts/ReaSpeech/Makefile
+++ b/reascripts/ReaSpeech/Makefile
@@ -4,7 +4,7 @@ LUA54=lua5.4
 LUAC54=luac5.4
 LUACHECK=luacheck
 
-LIBS=ImGuiTheme.lua Polo.lua ReaIter.lua ReaUtil.lua TableUtils.lua Tempfile.lua
+LIBS=ImGuiTheme.lua Polo.lua ReaIter.lua ReaUtil.lua Storage.lua TableUtils.lua Tempfile.lua
 VENDOR=json.lua url.lua
 
 source:=$(wildcard libs/*.lua source/*.lua source/include/*.lua)

--- a/reascripts/ReaSpeech/source/ASRControls.lua
+++ b/reascripts/ReaSpeech/source/ASRControls.lua
@@ -39,33 +39,58 @@ function ASRControls:init()
     Logging.show_debug_logs = current
   end)
 
+  local storage = Storage.ExtState.make {
+    section = 'ReaSpeech.ASR',
+    persist = true,
+  }
+
+  self.settings = {
+    language = storage:string('language', self.DEFAULT_LANGUAGE),
+    translate = storage:boolean('translate', false),
+    hotwords = storage:string('hotwords', ''),
+    initial_prompt = storage:string('initial_prompt', ''),
+    model_name = storage:string('model_name', self.DEFAULT_MODEL_NAME),
+    vad_filter = storage:boolean('vad_filter', true),
+  }
+
   self.language = ReaSpeechCombo.new {
-    default = self.DEFAULT_LANGUAGE,
+    state = self.settings.language,
     label = 'Language',
     items = WhisperLanguages.LANGUAGE_CODES,
     item_labels = WhisperLanguages.LANGUAGES
   }
 
   self.translate = ReaSpeechCheckbox.new {
-    default = false,
+    state = self.settings.translate,
     label_long = 'Translate to English',
     label_short = 'Translate',
     width_threshold = ReaSpeechControlsUI.NARROW_COLUMN_WIDTH
   }
 
-  self.hotwords = ReaSpeechTextInput.simple('', 'Hot Words')
-  self.initial_prompt = ReaSpeechTextInput.simple('', 'Initial Prompt')
-  self.model_name = ReaSpeechTextInput.simple(self.DEFAULT_MODEL_NAME, 'Model Name')
+  self.hotwords = ReaSpeechTextInput.new {
+    state = self.settings.hotwords,
+    label = 'Hot Words'
+  }
+
+  self.initial_prompt = ReaSpeechTextInput.new {
+    state = self.settings.initial_prompt,
+    label = 'Initial Prompt'
+  }
+
+  self.model_name = ReaSpeechTextInput.new {
+    state = self.settings.model_name,
+    label = 'Model Name'
+  }
 
   self.vad_filter = ReaSpeechCheckbox.new {
-    default = true,
+    state = self.settings.vad_filter,
     label_long = 'Voice Activity Detection',
     label_short = 'VAD',
     width_threshold = ReaSpeechControlsUI.NARROW_COLUMN_WIDTH
   }
 
   self.model_name_buttons = ReaSpeechButtonBar.new {
-    default = self.DEFAULT_MODEL_NAME,
+    state = self.settings.model_name,
     label = 'Model Name',
     buttons = self.SIMPLE_MODEL_SIZES,
     column_padding = ReaSpeechControlsUI.COLUMN_PADDING,

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -10,7 +10,7 @@ ReaSpeechWidget = Polo {
 function ReaSpeechWidget:init()
   if not self.state then
     assert(self.default ~= nil, "default value not provided")
-    self._value = self.default
+    self.state = Storage.memory(self.default)
   end
   assert(self.renderer, "renderer not provided")
   self.ctx = self.ctx or ctx
@@ -28,19 +28,11 @@ function ReaSpeechWidget:render(...)
 end
 
 function ReaSpeechWidget:value()
-  if self.state then
-    return self.state:get()
-  else
-    return self._value
-  end
+  return self.state:get()
 end
 
 function ReaSpeechWidget:set(value)
-  if self.state then
-    self.state:set(value)
-  else
-    self._value = value
-  end
+  self.state:set(value)
   if self.on_set then self:on_set() end
 end
 

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -8,7 +8,10 @@ ReaSpeechWidget = Polo {
 }
 
 function ReaSpeechWidget:init()
-  assert(self.default ~= nil, "default value not provided")
+  if not self.state then
+    assert(self.default ~= nil, "default value not provided")
+    self._value = self.default
+  end
   assert(self.renderer, "renderer not provided")
   self.ctx = self.ctx or ctx
   self.widget_id = self.widget_id or reaper.genGuid()
@@ -25,11 +28,19 @@ function ReaSpeechWidget:render(...)
 end
 
 function ReaSpeechWidget:value()
-  return self._value
+  if self.state then
+    return self.state:get()
+  else
+    return self._value
+  end
 end
 
 function ReaSpeechWidget:set(value)
-  self._value = value
+  if self.state then
+    self.state:set(value)
+  else
+    self._value = value
+  end
   if self.on_set then self:on_set() end
 end
 
@@ -38,6 +49,7 @@ end
 ReaSpeechCheckbox = {}
 ReaSpeechCheckbox.new = function (options)
   options = options or {
+    state = nil,
     default = nil,
     label_long = nil,
     label_short = nil,
@@ -47,14 +59,14 @@ ReaSpeechCheckbox.new = function (options)
   options.changed_handler = options.changed_handler or function(_) end
 
   local o = ReaSpeechWidget.new({
+    state = options.state,
     default = options.default,
     widget_id = options.widget_id,
     renderer = ReaSpeechCheckbox.renderer,
     options = options,
   })
 
-  o._value = o.default
-  options.changed_handler(o.default)
+  options.changed_handler(o:value())
 
   return o
 end
@@ -88,18 +100,18 @@ end
 ReaSpeechTextInput = {}
 ReaSpeechTextInput.new = function (options)
   options = options or {
+    state = nil,
     default = nil,
     label = nil,
   }
 
   local o = ReaSpeechWidget.new({
+    state = options.state,
     default = options.default,
     widget_id = options.widget_id,
     renderer = ReaSpeechTextInput.renderer,
     options = options,
   })
-
-  o._value = o.default
 
   return o
 end
@@ -130,6 +142,7 @@ ReaSpeechCombo = {}
 
 ReaSpeechCombo.new = function (options)
   options = options or {
+    state = nil,
     default = nil,
     label = nil,
     items = {},
@@ -137,13 +150,12 @@ ReaSpeechCombo.new = function (options)
   }
 
   local o = ReaSpeechWidget.new({
+    state = options.state,
     default = options.default,
     widget_id = options.widget_id,
     renderer = ReaSpeechCombo.renderer,
     options = options,
   })
-
-  o._value = o.default
 
   return o
 end
@@ -184,8 +196,6 @@ ReaSpeechTabBar.new = function (options)
     options = options,
   })
 
-  o._value = o.default
-
   return o
 end
 
@@ -214,6 +224,7 @@ ReaSpeechButtonBar = {}
 
 ReaSpeechButtonBar.new = function (options)
   options = options or {
+    state = nil,
     default = nil,
     label = nil,
     buttons = {},
@@ -221,13 +232,12 @@ ReaSpeechButtonBar.new = function (options)
   }
 
   local o = ReaSpeechWidget.new({
+    state = options.state,
     default = options.default,
     widget_id = options.widget_id,
     renderer = ReaSpeechButtonBar.renderer,
     options = options,
   })
-
-  o._value = o.default
 
   local with_button_color = function (selected, f)
     if selected then
@@ -340,8 +350,6 @@ ReaSpeechFileSelector.new = function(options)
       end
     end
   })
-
-  o._value = o.default
 
   return o
 end

--- a/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
@@ -4,6 +4,7 @@ local lu = require('luaunit')
 
 require('Polo')
 require('ReaUtil')
+require('Storage')
 require('mock_reaper')
 
 require('source/AlertPopup')

--- a/reascripts/common/libs/Storage.lua
+++ b/reascripts/common/libs/Storage.lua
@@ -60,6 +60,11 @@
         project (integer) - The project identifier.
         extname (string) - The extension name for the ProjExtState data.
 
+    Storage.memory(value)
+      Create a memory storage cell.
+
+      value (any) - The initial value for the storage data.
+
     storage:boolean(key, default)
       Create a boolean storage cell.
 
@@ -97,6 +102,14 @@ Storage = {
   end,
 }
 Storage.__index = Storage
+
+function Storage.memory(value)
+  return Storage.Cell.new {
+    get = function () return value end,
+    set = function (new_value) value = new_value end,
+    erase = function () value = nil end,
+  }
+end
 
 function Storage:boolean(key, default)
   local engine = self.engine

--- a/reascripts/common/tests/TestStorage.lua
+++ b/reascripts/common/tests/TestStorage.lua
@@ -77,11 +77,7 @@ function TestStorage:testProjExtState()
 end
 
 function TestStorage:testDerivedCell()
-  local settings = Storage.ExtState.make {
-    section = 'MyScript.Settings',
-  }
-
-  local my_setting = settings:string('my_setting', '')
+  local my_setting = Storage.memory('')
 
   local my_derived_setting = Storage.Cell.new {
     get = function () return my_setting:get():upper() end,


### PR DESCRIPTION
Use the new Storage library to make ASR controls persistent across launches of the application.

Added a Storage.memory helper for creating memory-based cells.