### PR TITLE
Revert ToolWindow application to ReaSpeechUI

### DIFF
--- a/reascripts/ReaSpeech/source/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechMain.lua
@@ -16,20 +16,36 @@ function ReaSpeechMain:main()
   ctx = ImGui.CreateContext(ReaSpeechUI.TITLE, ReaSpeechUI.config_flags())
   Fonts:load()
   app = ReaSpeechUI.new()
-  app:open()
-
   reaper.defer(self:loop())
 end
 
 function ReaSpeechMain:loop()
+  local visible, open = false, false
+
   return function()
-    if ReaSpeechUI.METRICS then
-      ImGui.ShowMetricsWindow(ctx)
-    end
+    ImGui.PushFont(ctx, Fonts.main)
+    app:trap(function()
+      Theme():push(ctx)
+      app:trap(function()
+        if ReaSpeechUI.METRICS then
+          ImGui.ShowMetricsWindow(ctx)
+        end
 
-    if app:is_open() then
-      app:trap(function() app:react() end)
+        ImGui.SetNextWindowSize(ctx, app.WIDTH, app.HEIGHT, ImGui.Cond_FirstUseEver())
+        visible, open = ImGui.Begin(ctx, ReaSpeechUI.TITLE, true)
 
+        if visible then
+          app:trap(function()
+            app:react()
+          end)
+          ImGui.End(ctx)
+        end
+      end)
+      Theme():pop(ctx)
+    end)
+    ImGui.PopFont(ctx)
+
+    if open then
       reaper.defer(self:loop())
     end
   end

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -19,17 +19,6 @@ ReaSpeechUI = Polo {
 function ReaSpeechUI:init()
   Logging.init(self, 'ReaSpeechUI')
 
-  ToolWindow.init(self, {
-    ctx = ctx,
-    title = self.TITLE,
-    width = self.WIDTH,
-    height = self.HEIGHT,
-    window_flags = ImGui.WindowFlags_None(),
-    font = Fonts.main,
-    theme = Theme(),
-    position = ToolWindow.POSITION_AUTOMATIC,
-  })
-
   self.onerror = function (e)
     self:log(e)
   end
@@ -116,7 +105,7 @@ function ReaSpeechUI:react_to_worker_response()
   end
 end
 
-function ReaSpeechUI:render_content()
+function ReaSpeechUI:render()
   ImGui.PushItemWidth(ctx, self.ITEM_WIDTH)
 
   self:trap(function ()


### PR DESCRIPTION
For some reason we don't understand yet, using ToolWindow for ReaSpeechUI causes AlertPopups to fail to display in case of ASR errors (like when the model name is invalid). Popups from the Export modal are not affected. This revert fixes the main build while we look into the issue.