### PR TITLE
Use tab bar for annotations, tweak defaults

### DIFF
--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -25,7 +25,8 @@ function TranscriptExporter:init()
     window_flags = 0
       | ImGui.WindowFlags_AlwaysAutoResize()
       | ImGui.WindowFlags_NoCollapse()
-      | ImGui.WindowFlags_NoDocking(),
+      | ImGui.WindowFlags_NoDocking()
+      | ImGui.WindowFlags_TopMost(),
   })
 
   self.export_formats = TranscriptExporterFormats.new {

--- a/reascripts/common/libs/mock_reaper.lua
+++ b/reascripts/common/libs/mock_reaper.lua
@@ -160,6 +160,7 @@ ImGui = ImGui or {
   WindowFlags_AlwaysAutoResize = function() return 1 end,
   WindowFlags_NoCollapse = function() return 2 end,
   WindowFlags_NoDocking = function() return 3 end,
+  WindowFlags_TopMost = function() return 4 end,
   Cond_FirstUseEver = function() return 0 end,
   Cond_Appearing = function() return 1 end,
 }


### PR DESCRIPTION
A few changes to the transcript annotations UI:

- Use a tab bar instead of a combo box for the annotation type
- Default to project markers
- Default to segment granularity
- Ensure that popup windows stay on top