### PR TITLE
ToolWindow fixes

### DIFF
--- a/reascripts/ReaSpeech/libs/ToolWindow.lua
+++ b/reascripts/ReaSpeech/libs/ToolWindow.lua
@@ -108,7 +108,6 @@ ToolWindow.modal = function(o, config)
 end
 
 ToolWindow.init = function(o, config)
-  Logging.init(o, 'ToolWindow')
   config = config or {}
 
   o.ctx = config.ctx or ctx
@@ -125,10 +124,10 @@ ToolWindow.init = function(o, config)
     state.is_open = false
   end)
 
+  o.is_open = ToolWindow.is_open
+
   o.present = ToolWindow.present
   o.presenting = ToolWindow.presenting
-
-  o.is_open = ToolWindow.is_open
 
   o.render = ToolWindow.render
 

--- a/reascripts/ReaSpeech/source/AlertPopup.lua
+++ b/reascripts/ReaSpeech/source/AlertPopup.lua
@@ -28,7 +28,7 @@ end
 function AlertPopup:show(title, msg)
   self._tool_window.title = title or self._tool_window.title
   self.msg = msg
-  self:open()
+  self:present()
 end
 
 function AlertPopup:render_content()

--- a/reascripts/ReaSpeech/source/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechMain.lua
@@ -16,36 +16,14 @@ function ReaSpeechMain:main()
   ctx = ImGui.CreateContext(ReaSpeechUI.TITLE, ReaSpeechUI.config_flags())
   Fonts:load()
   app = ReaSpeechUI.new()
+  app:present()
   reaper.defer(self:loop())
 end
 
 function ReaSpeechMain:loop()
-  local visible, open = false, false
-
   return function()
-    ImGui.PushFont(ctx, Fonts.main)
-    app:trap(function()
-      Theme():push(ctx)
-      app:trap(function()
-        if ReaSpeechUI.METRICS then
-          ImGui.ShowMetricsWindow(ctx)
-        end
-
-        ImGui.SetNextWindowSize(ctx, app.WIDTH, app.HEIGHT, ImGui.Cond_FirstUseEver())
-        visible, open = ImGui.Begin(ctx, ReaSpeechUI.TITLE, true)
-
-        if visible then
-          app:trap(function()
-            app:react()
-          end)
-          ImGui.End(ctx)
-        end
-      end)
-      Theme():pop(ctx)
-    end)
-    ImGui.PopFont(ctx)
-
-    if open then
+    if app:presenting() or app:is_open() then
+      app:trap(function() app:react() end)
       reaper.defer(self:loop())
     end
   end

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -30,10 +30,6 @@ function ReaSpeechUI:init()
 
   Logging.init(self, 'ReaSpeechUI')
 
-  if ReaSpeechUI.METRICS then
-    ImGui.ShowMetricsWindow(ctx)
-  end
-
   self.onerror = function (e)
     self:log(e)
   end
@@ -121,6 +117,10 @@ function ReaSpeechUI:react_to_worker_response()
 end
 
 function ReaSpeechUI:render_content()
+  if ReaSpeechUI.METRICS then
+    ImGui.ShowMetricsWindow(ctx)
+  end
+
   ImGui.PushItemWidth(ctx, self.ITEM_WIDTH)
 
   self:trap(function ()

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -17,7 +17,22 @@ ReaSpeechUI = Polo {
 }
 
 function ReaSpeechUI:init()
+  ToolWindow.init(self, {
+    ctx = ctx,
+    title = self.TITLE,
+    width = self.WIDTH,
+    height = self.HEIGHT,
+    window_flags = ImGui.WindowFlags_None(),
+    font = Fonts.main,
+    theme = Theme(),
+    position = ToolWindow.POSITION_AUTOMATIC,
+  })
+
   Logging.init(self, 'ReaSpeechUI')
+
+  if ReaSpeechUI.METRICS then
+    ImGui.ShowMetricsWindow(ctx)
+  end
 
   self.onerror = function (e)
     self:log(e)
@@ -105,7 +120,7 @@ function ReaSpeechUI:react_to_worker_response()
   end
 end
 
-function ReaSpeechUI:render()
+function ReaSpeechUI:render_content()
   ImGui.PushItemWidth(ctx, self.ITEM_WIDTH)
 
   self:trap(function ()

--- a/reascripts/ReaSpeech/source/ReaSpeechWelcomeUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWelcomeUI.lua
@@ -33,19 +33,12 @@ function ReaSpeechWelcomeUI:init()
     width = self.WIDTH,
     height = self.HEIGHT,
     window_flags = ImGui.WindowFlags_AlwaysAutoResize(),
-    guard = function() return self.presenting end,
     theme = ImGuiTheme.new({
       styles = {
         {ImGui.StyleVar_WindowPadding, 0, 0 },
       }
     }),
   })
-
-  self.presenting = false
-end
-
-function ReaSpeechWelcomeUI:present()
-  self.presenting = true
 end
 
 function ReaSpeechWelcomeUI:render_content()
@@ -125,8 +118,4 @@ function ReaSpeechWelcomeUI:render_footer()
   Widgets.link("GitHub", ReaUtil.url_opener(self.GITHUB_URL))
   ImGui.SameLine(ctx)
   Widgets.link("Docker Hub", ReaUtil.url_opener(self.DOCKER_HUB_URL))
-end
-
-function ReaSpeechWelcomeUI:close()
-  self.presenting = false
 end

--- a/reascripts/ReaSpeech/source/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptUI.lua
@@ -77,7 +77,7 @@ end
 
 function TranscriptUI:render_annotations_button(column)
   if ImGui.Button(ctx, "Create Markers", column.width) then
-    self.annotations:open()
+    self.annotations:present()
   end
 end
 
@@ -146,7 +146,7 @@ function TranscriptUI:render_search(column)
 end
 
 function TranscriptUI:handle_export()
-  self.transcript_exporter:open()
+  self.transcript_exporter:present()
 end
 
 function TranscriptUI:handle_transcript_clear()

--- a/reascripts/ReaSpeech/tests/TestToolWindow.lua
+++ b/reascripts/ReaSpeech/tests/TestToolWindow.lua
@@ -74,6 +74,22 @@ function TestToolWindow:testModal()
   lu.assertEquals(o._tool_window.height, 200)
 end
 
+function TestToolWindow:testPresentAndPresenting()
+  local test_class = Polo {
+    init = function(self)
+      ToolWindow.init(self)
+    end
+  }
+
+  local o = test_class.new()
+  lu.assertNotNil(o._tool_window)
+  lu.assertEquals(o:presenting(), false)
+  o:present()
+  lu.assertEquals(o:presenting(), true)
+  o:close()
+  lu.assertEquals(o:presenting(), false)
+end
+
 function TestToolWindow:testIsOpen()
   local test_class = Polo {
     init = function(self)
@@ -182,7 +198,7 @@ function TestToolWindow:testRender()
 
   ImGui.Cond_Appearing = function() return 1 end
   ImGui.Cond_FirstUseEver = function() return 2 end
-  ImGui.End = function() end
+  ImGui.End = function(_) end
   ImGui.GetWindowViewport = function() end
   ImGui.SetNextWindowPos = function(_, _, _, _, _, _) end
   ImGui.SetNextWindowSize = function(_, _, _, _) end


### PR DESCRIPTION
The `present`/`presenting` is now baked in by default. Using `present` instead of `open` provides some safety when trying to open a window when you might not be safely within a `render` call.

This was a problem that manifested as the `AlertPopup` not popping up when a transcription error occurred. Internally, its `show` method was calling `open`. Roughly what was happening was that it was trying to attach a popup without any active `Begin`/`End` parent window context to attach to (plz forgive this bad and possibly incomplete/incorrect interpretation and articulation).