### PR TITLE
Tweening module for that smoothe taste 

### DIFF
--- a/reascripts/ReaSpeech/libs/ToolWindow.lua
+++ b/reascripts/ReaSpeech/libs/ToolWindow.lua
@@ -88,7 +88,11 @@ ToolWindow = {
   end,
 
   DEFAULT_THEME = function()
-    return ImGuiTheme.new()
+    return ImGuiTheme.new {
+      styles = {
+        { ImGui.StyleVar_Alpha, 0 }
+      },
+    }
   end,
 }
 
@@ -113,9 +117,24 @@ ToolWindow.init = function(o, config)
   o.ctx = config.ctx or ctx
 
   local state = ToolWindow._make_config(o, config)
+
+  state.theme:set_style(ImGui.StyleVar_Alpha, 0)
+
   o._tool_window = state
 
   ToolWindow._wrap_method_0_args(o, 'open', function()
+    local theme = o._tool_window.theme
+
+    local final_alpha = theme:get_style(ImGui.StyleVar_Alpha) or 1.0
+
+    local tween = Tween.linear(0.0, 1.0, 0.2, function()
+      theme:set_style(ImGui.StyleVar_Alpha, final_alpha)
+    end)
+
+    theme:set_style(ImGui.StyleVar_Alpha, function()
+      return { tween() }
+    end)
+
     state.is_open = true
   end)
 

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -18,6 +18,12 @@ function TranscriptExporter:init()
 
   Logging.init(self, 'TranscriptExporter')
 
+  self.theme = ImGuiTheme.new {
+    styles = {
+      { ImGui.StyleVar_Alpha, 0 },
+    }
+  }
+
   ToolWindow.init(self, {
     title = self.TITLE,
     width = self.WIDTH,
@@ -27,6 +33,7 @@ function TranscriptExporter:init()
       | ImGui.WindowFlags_NoCollapse()
       | ImGui.WindowFlags_NoDocking()
       | ImGui.WindowFlags_TopMost(),
+    theme = self.theme,
   })
 
   self.export_formats = TranscriptExporterFormats.new {
@@ -43,6 +50,10 @@ function TranscriptExporter:init()
   })
 
   self.alert_popup = AlertPopup.new {}
+end
+
+function TranscriptExporter:open()
+  self.theme.styles[1][2] = Tween.linear(0.0, 1.0, 0.2)
 end
 
 function TranscriptExporter:show_success()

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -57,15 +57,15 @@ function TranscriptExporter:open()
 
   local on_done = function()
     -- set the style to a static value
-    self.theme.styles[1][2] = opaque
+    self.theme:set_style(ImGui.StyleVar_Alpha, opaque)
   end
 
   local tween = Tween.linear(transparent, opaque, duration, on_done)
 
   -- activate the tween as a style-returning function
-  self.theme.styles[1][2] = function()
+  self.theme:set_style(ImGui.StyleVar_Alpha, function()
     return { tween() }
-  end
+  end)
 end
 
 function TranscriptExporter:show_success()

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -53,11 +53,19 @@ function TranscriptExporter:init()
 end
 
 function TranscriptExporter:open()
-  local tween = Tween.linear(0.0, 1.0, 0.2, function()
-    self.theme.styles[1][2] = 1.0
-  end)
+  local transparent, opaque, duration = 0.0, 1.0, 0.2
 
-  self.theme.styles[1][2] = function() return {tween()} end
+  local on_done = function()
+    -- set the style to a static value
+    self.theme.styles[1][2] = opaque
+  end
+
+  local tween = Tween.linear(transparent, opaque, duration, on_done)
+
+  -- activate the tween as a style-returning function
+  self.theme.styles[1][2] = function()
+    return { tween() }
+  end
 end
 
 function TranscriptExporter:show_success()

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -18,12 +18,6 @@ function TranscriptExporter:init()
 
   Logging.init(self, 'TranscriptExporter')
 
-  self.theme = ImGuiTheme.new {
-    styles = {
-      { ImGui.StyleVar_Alpha, 0 },
-    }
-  }
-
   ToolWindow.init(self, {
     title = self.TITLE,
     width = self.WIDTH,
@@ -33,7 +27,6 @@ function TranscriptExporter:init()
       | ImGui.WindowFlags_NoCollapse()
       | ImGui.WindowFlags_NoDocking()
       | ImGui.WindowFlags_TopMost(),
-    theme = self.theme,
   })
 
   self.export_formats = TranscriptExporterFormats.new {
@@ -50,22 +43,6 @@ function TranscriptExporter:init()
   })
 
   self.alert_popup = AlertPopup.new {}
-end
-
-function TranscriptExporter:open()
-  local transparent, opaque, duration = 0.0, 1.0, 0.2
-
-  local on_done = function()
-    -- set the style to a static value
-    self.theme:set_style(ImGui.StyleVar_Alpha, opaque)
-  end
-
-  local tween = Tween.linear(transparent, opaque, duration, on_done)
-
-  -- activate the tween as a style-returning function
-  self.theme:set_style(ImGui.StyleVar_Alpha, function()
-    return { tween() }
-  end)
 end
 
 function TranscriptExporter:show_success()

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -53,7 +53,11 @@ function TranscriptExporter:init()
 end
 
 function TranscriptExporter:open()
-  self.theme.styles[1][2] = Tween.linear(0.0, 1.0, 0.2)
+  local tween = Tween.linear(0.0, 1.0, 0.2, function()
+    self.theme.styles[1][2] = 1.0
+  end)
+
+  self.theme.styles[1][2] = function() return {tween()} end
 end
 
 function TranscriptExporter:show_success()

--- a/reascripts/ReaSpeech/source/Tween.lua
+++ b/reascripts/ReaSpeech/source/Tween.lua
@@ -50,10 +50,8 @@ Tween = {
 
       t.__call = function(self)
         local time = time_f()
-        self:debug('tween called @ ' .. time)
 
         if time >= t.start_time + t.duration then
-          self:debug('tween done')
           if t.on_end then
             self.on_end()
             self.on_end = function() end
@@ -71,7 +69,6 @@ Tween = {
       end
 
       setmetatable(t, t)
-      Logging.init(t, 'Tween')
       return t
     end
 

--- a/reascripts/ReaSpeech/source/Tween.lua
+++ b/reascripts/ReaSpeech/source/Tween.lua
@@ -2,6 +2,35 @@
 
   Tween.lua - basic tweens for animation
 
+  Usage:
+    local tween -- an instance of a Tween(...)
+        , value -- calling tween() will return the current value
+
+    -- use a predefined tween function
+
+    local start_value = 0
+    local end_value = 1
+    local duration = 0.2
+    local on_end = function()
+      -- optionally do something when the tween is done
+    end
+
+    tween = Tween.linear(start_value, end_value, duration, on_end)
+
+    value = tween()
+
+    -- or define your own tween function like the module does
+
+    local time_function = function() return 0 end
+      -- default: ...or reaper and reaper.time_precise
+
+    local my_linear_tween = Tween(function(t, b, c, d)
+      return b + c * t / d
+    end, time_function)
+
+    tween = my_linear_tween(0.0, 1.0, 0.2, on_end)
+
+    value = tween()
 ]]--
 
 Tween = {

--- a/reascripts/ReaSpeech/source/Tween.lua
+++ b/reascripts/ReaSpeech/source/Tween.lua
@@ -83,3 +83,13 @@ setmetatable(Tween, Tween)
 Tween.linear = Tween(function(t, b, c, d)
   return b + c * t / d
 end)
+
+Tween.inQuad = Tween(function(t, b, c, d)
+  t = t / d
+  return c * t ^ 2 + b
+end)
+
+Tween.inCubic = Tween(function(t, b, c, d)
+  t = t / d
+  return c * t ^ 3 + b
+end)

--- a/reascripts/ReaSpeech/source/Tween.lua
+++ b/reascripts/ReaSpeech/source/Tween.lua
@@ -1,0 +1,54 @@
+--[[
+
+  Tween.lua - basic tweens for animation
+
+]]--
+
+Tween = Polo {
+  new = function(start_value, end_value, duration)
+    local self = {}
+    self.start_value = start_value
+    self.end_value = end_value
+    self.duration = duration
+    return self
+  end,
+}
+
+function Tween:init()
+  self.current_value = self.start_value
+  self:reset()
+end
+
+function Tween:update()
+  local current_time = reaper.time_precise()
+
+  if self:is_done(current_time) then return end
+
+  local progress = (current_time - self.start_time) / (self.end_time - self.start_time)
+  self.current_value = self.start_value + (self.end_value - self.start_value) * progress
+end
+
+function Tween:reset()
+  self.start_time = reaper.time_precise()
+  self.end_time = self.start_time + self.duration
+end
+
+function Tween:is_done(current_time)
+  current_time = current_time or reaper.time_precise()
+  return current_time >= self.end_time
+end
+
+function Tween:value()
+  self:update()
+  if self:is_done() then
+    return self.end_value
+  else
+    return self.current_value
+  end
+end
+
+function Tween.linear(start, end_, duration)
+  local t = Tween.new(start, end_, duration)
+
+  return function() return { t:value() } end
+end

--- a/reascripts/ReaSpeech/tests/TestToolWindow.lua
+++ b/reascripts/ReaSpeech/tests/TestToolWindow.lua
@@ -8,6 +8,7 @@ require('Polo')
 require('Storage')
 require('libs/ToolWindow')
 require('source/Logging')
+require('source/Tween')
 require('source/include/globals')
 
 --

--- a/reascripts/ReaSpeech/tests/TestTween.lua
+++ b/reascripts/ReaSpeech/tests/TestTween.lua
@@ -2,17 +2,17 @@ package.path = '../common/libs/?.lua;../common/vendor/?.lua;' .. package.path
 
 local lu = require('luaunit')
 
--- require('mock_reaper')
 require('Polo')
 require('Storage')
 require('source/Logging')
-require('source/Tween')
 
 reaper = {
   time_precise = function()
     return 0
   end
 }
+
+require('source/Tween')
 
 --
 
@@ -61,6 +61,37 @@ function TestTween:testCallback()
   time = 1
   lu.assertEquals(tween(), 10)
   lu.assertEquals(callback_called, true)
+end
+
+function TestTween:testDocumentation()
+  local tween -- an instance of a Tween(...)
+      , value -- calling tween() will return the current value
+
+  -- use a predefined tween function
+
+  local start_value = 0
+  local end_value = 1
+  local duration = 0.2
+  local on_end = function()
+    -- optionally do something when the tween is done
+  end
+
+  tween = Tween.linear(start_value, end_value, duration, on_end)
+
+  value = tween()
+
+  -- or define your own tween function like the module does
+
+  local time_function = function() return 0 end
+    -- default: ...or reaper and reaper.time_precise
+
+  local my_linear_tween = Tween(function(t, b, c, d)
+    return b + c * t / d
+  end, time_function)
+
+  tween = my_linear_tween(0.0, 1.0, 0.2, on_end)
+
+  value = tween()
 end
 
 --

--- a/reascripts/ReaSpeech/tests/TestTween.lua
+++ b/reascripts/ReaSpeech/tests/TestTween.lua
@@ -1,0 +1,30 @@
+package.path = '../common/libs/?.lua;../common/vendor/?.lua;' .. package.path
+
+local lu = require('luaunit')
+
+-- require('mock_reaper')
+require('Polo')
+require('Storage')
+require('source/Logging')
+require('source/Tween')
+
+reaper = {
+  time_precise = function()
+    return 0
+  end
+}
+
+--
+
+TestTween = {}
+
+function TestTween:testNew()
+  local start_value = 0
+  local end_value = 1
+  local duration = 1
+  local tween = Tween.new(start_value, end_value, duration)
+end
+
+--
+
+os.exit(lu.LuaUnit.run())

--- a/reascripts/ReaSpeech/tests/TestTween.lua
+++ b/reascripts/ReaSpeech/tests/TestTween.lua
@@ -4,7 +4,6 @@ local lu = require('luaunit')
 
 require('Polo')
 require('Storage')
-require('source/Logging')
 
 reaper = {
   time_precise = function()

--- a/reascripts/ReaSpeech/tests/TestTween.lua
+++ b/reascripts/ReaSpeech/tests/TestTween.lua
@@ -19,10 +19,48 @@ reaper = {
 TestTween = {}
 
 function TestTween:testNew()
-  local start_value = 0
-  local end_value = 1
+  local start_value = 1
+  local end_value = 10
   local duration = 1
-  local tween = Tween.new(start_value, end_value, duration)
+  local time = 0
+  local f = function(t, b, c, d)
+    lu.assertEquals(t, 0)
+    lu.assertEquals(b, start_value)
+    lu.assertEquals(c, end_value - start_value)
+    lu.assertEquals(d, duration)
+    return "derp"
+  end
+
+  local boring_tween = Tween(f, function() return time end)
+
+  local tween = boring_tween(start_value, end_value, duration)
+
+  lu.assertEquals(tween(), "derp")
+end
+
+function TestTween:testCallback()
+  local start_value = 1
+  local end_value = 10
+  local duration = 1
+  local time = 0
+  local f = function(t, b, c, d)
+    return b + c * t / d
+  end
+
+  local boring_tween = Tween(f, function() return time end)
+
+  local callback_called = false
+
+  local tween = boring_tween(start_value, end_value, duration, function()
+    callback_called = true
+  end)
+
+  lu.assertEquals(callback_called, false)
+  lu.assertEquals(tween(), 1)
+  lu.assertEquals(callback_called, false)
+  time = 1
+  lu.assertEquals(tween(), 10)
+  lu.assertEquals(callback_called, true)
 end
 
 --

--- a/reascripts/common/libs/ImGuiTheme.lua
+++ b/reascripts/common/libs/ImGuiTheme.lua
@@ -65,10 +65,16 @@ ImGuiTheme.get_function = function(key, default)
   return ImGuiTheme[key] or default
 end
 
-function ImGuiTheme._attr_row(key, value)
+function ImGuiTheme._attr_key(key)
   if type(key) == 'function' then
-    key = key()
+    return key()
   end
+
+  return key
+end
+
+function ImGuiTheme._attr_row(key, value)
+  key = ImGuiTheme._attr_key(key)
 
   if type(value) == 'table' then
     return { key, table.unpack(value) }
@@ -77,12 +83,37 @@ function ImGuiTheme._attr_row(key, value)
   return { key, value }
 end
 
-function ImGuiTheme:set_style(key, value)
-  self.styles = ImGuiTheme._set_attr(self.styles, key, value)
+function ImGuiTheme:get_color(key)
+  return ImGuiTheme:_get_attr(self.colors, key)
+end
+
+function ImGuiTheme:get_style(key)
+  return ImGuiTheme:_get_attr(self.styles, key)
+end
+
+function ImGuiTheme:_get_attr(attr_table, key)
+  for _, v in ipairs(attr_table) do
+    if v[1] == key then
+      local result = { select(2, table.unpack(v)) }
+      if #result == 1 then
+        if type(result[1]) == 'function' then
+          return result[1]()
+        else
+          return result[1]
+        end
+      else
+        return result
+      end
+    end
+  end
 end
 
 function ImGuiTheme:set_color(key, value)
   self.colors = ImGuiTheme._set_attr(self.colors, key, value)
+end
+
+function ImGuiTheme:set_style(key, value)
+  self.styles = ImGuiTheme._set_attr(self.styles, key, value)
 end
 
 function ImGuiTheme._set_attr(attr_table, key, value)

--- a/reascripts/common/libs/ImGuiTheme.lua
+++ b/reascripts/common/libs/ImGuiTheme.lua
@@ -77,7 +77,13 @@ function ImGuiTheme:push(ctx)
   self.style_count = 0
   for i = 1, #self.styles do
     if self.styles[i][1] then
-      self.f_style_push(ctx, self.styles[i][1], table.unpack(self.styles[i], 2))
+      local args
+      if type(self.styles[i][2]) == 'function' then
+        args = self.styles[i][2]()
+      else
+        args = {table.unpack(self.styles[i], 2)}
+      end
+      self.f_style_push(ctx, self.styles[i][1], table.unpack(args))
       self.style_count = self.style_count + 1
     end
   end

--- a/reascripts/common/libs/ImGuiTheme.lua
+++ b/reascripts/common/libs/ImGuiTheme.lua
@@ -65,6 +65,41 @@ ImGuiTheme.get_function = function(key, default)
   return ImGuiTheme[key] or default
 end
 
+function ImGuiTheme._attr_row(key, value)
+  if type(key) == 'function' then
+    key = key()
+  end
+
+  if type(value) == 'table' then
+    return { key, table.unpack(value) }
+  end
+
+  return { key, value }
+end
+
+function ImGuiTheme:set_style(key, value)
+  self.styles = ImGuiTheme._set_attr(self.styles, key, value)
+end
+
+function ImGuiTheme:set_color(key, value)
+  self.colors = ImGuiTheme._set_attr(self.colors, key, value)
+end
+
+function ImGuiTheme._set_attr(attr_table, key, value)
+  local row = ImGuiTheme._attr_row(key, value)
+
+  local result = {}
+  for _, v in ipairs(attr_table) do
+    if v[1] == row[1] then
+      table.insert(result, row)
+    else
+      table.insert(result, v)
+    end
+  end
+
+  return result
+end
+
 function ImGuiTheme:push(ctx)
   self.color_count = 0
   for i = 1, #self.colors do

--- a/reascripts/common/libs/mock_reaper.lua
+++ b/reascripts/common/libs/mock_reaper.lua
@@ -114,6 +114,8 @@ reaper = reaper or {
 
   ImGui_BeginDisabled = function(_context, _disabled) end,
   ImGui_EndDisabled = function(_context) end,
+
+  time_precise = function() return 0 end,
 }
 
 if reaper.__test_setUp then reaper.__test_setUp() end

--- a/reascripts/common/tests/TestImGuiTheme.lua
+++ b/reascripts/common/tests/TestImGuiTheme.lua
@@ -92,13 +92,15 @@ function TestImGuiTheme:testStyles()
   local theme = ImGuiTheme.new {
     styles = {
       { function() return "single argument" end, 1.0 },
-      { "multiple arguments", 2.0, 3.0 }
+      { "multiple arguments", 2.0, 3.0 },
+      { "function argument", function() return { 4.0, 5.0 } end }
   }
 }
 
   local expectations = {
     { "single argument", 1.0 },
-    { "multiple arguments", 2.0, 3.0 }
+    { "multiple arguments", 2.0, 3.0 },
+    { "function argument", 4.0, 5.0 }
   }
 
   local i = 1
@@ -111,7 +113,7 @@ function TestImGuiTheme:testStyles()
   end
 
   ImGuiTheme.f_style_pop = function(_ctx, count)
-    lu.assertEquals(count, 2)
+    lu.assertEquals(count, 3)
   end
 
   theme:push("context")

--- a/reascripts/common/tests/TestImGuiTheme.lua
+++ b/reascripts/common/tests/TestImGuiTheme.lua
@@ -144,6 +144,105 @@ function TestImGuiTheme:testWrap()
   lu.assertEquals(function_called, true)
 end
 
+function TestImGuiTheme:testSetStyle()
+  local theme = ImGuiTheme.new {
+    styles = {
+      { function() return "single argument" end, 1.0 },
+      { "multiple arguments", 2.0, 3.0 },
+      { "function argument", function() return { 4.0, 5.0 } end }
+    }
+  }
+
+  local expectations = {
+    { "single argument", 1.0 },
+    { "multiple arguments", 2.0, 3.0 },
+    { "function argument", 4.0, 5.0 },
+  }
+  local i = 1
+  ImGuiTheme.f_style_push = function(_ctx, key, ...)
+    local values = ...
+    lu.assertEquals(key, expectations[i][1])
+    lu.assertEquals(values, table.unpack(expectations[i], 2))
+    i = i + 1
+  end
+
+  ImGuiTheme.f_style_pop = function(_ctx, count)
+    lu.assertEquals(count, 3)
+  end
+
+  theme:push("context")
+  theme:pop("context")
+
+  theme:set_style("new style", 2.0)
+  expectations[4] = { "new style", 2.0 }
+
+  ImGuiTheme.f_style_pop = function(_ctx, count)
+    lu.assertEquals(count, 4)
+  end
+
+  theme:push("context")
+  theme:pop("context")
+
+  theme:set_style("new style", 3.0)
+  expectations[4] = { "new style", 3.0 }
+
+  ImGuiTheme.f_style_pop = function(_ctx, count)
+    lu.assertEquals(count, 4)
+  end
+
+  theme:push("context")
+  theme:pop("context")
+end
+
+function TestImGuiTheme:testSetColor()
+  local theme = ImGuiTheme.new {
+    colors = {
+        { function() return "some key" end, 0xFF0000FF },
+        { "just a key", 0x00FF0000 }
+    }
+  }
+
+  local expectations = {
+    { "some key", 0xFF0000FF },
+    { "just a key", 0x00FF0000 }
+  }
+
+  local i = 1
+  ImGuiTheme.f_color_push = function(_ctx, key, ...)
+    local values = ...
+    lu.assertEquals(key, expectations[i][1])
+    lu.assertEquals(values, table.unpack(expectations[i], 2))
+    i = i + 1
+  end
+
+  ImGuiTheme.f_color_pop = function(_ctx, count)
+    lu.assertEquals(count, 2)
+  end
+
+  theme:push("context")
+  theme:pop("context")
+
+  theme:set_color("new color", 0x00FFFF00)
+  expectations[3] = { "new color", 0x00FFFF00 }
+
+  ImGuiTheme.f_color_pop = function(_ctx, count)
+    lu.assertEquals(count, 3)
+  end
+
+  theme:push("context")
+  theme:pop("context")
+
+  theme:set_color("new color", 0x00FFFF01)
+  expectations[3] = { "new color", 0x00FFFF01 }
+
+  ImGuiTheme.f_color_pop = function(_ctx, count)
+    lu.assertEquals(count, 3)
+  end
+
+  theme:push("context")
+  theme:pop("context")
+end
+
 --
 
 os.exit(lu.LuaUnit.run())

--- a/reascripts/common/tests/TestImGuiTheme.lua
+++ b/reascripts/common/tests/TestImGuiTheme.lua
@@ -144,6 +144,32 @@ function TestImGuiTheme:testWrap()
   lu.assertEquals(function_called, true)
 end
 
+function TestImGuiTheme:testGetStyle()
+  local theme = ImGuiTheme.new {
+    styles = {
+      { function() return "single argument" end, 1.0 },
+      { "multiple arguments", 2.0, 3.0 },
+      { "function argument", function() return { 4.0, 5.0 } end }
+    }
+  }
+
+  lu.assertEquals(theme:get_style("single argument"), 1.0)
+  lu.assertEquals(theme:get_style("multiple arguments"), { 2.0, 3.0 })
+  lu.assertEquals(theme:get_style("function argument"), { 4.0, 5.0 })
+end
+
+function TestImGuiTheme:testGetColor()
+  local theme = ImGuiTheme.new {
+    colors = {
+      { function() return "single argument" end, 0x00FF0000 },
+      { "key", 0x00FF0001 }
+    }
+  }
+
+  lu.assertEquals(theme:get_color("single argument"), 0x00FF0000)
+  lu.assertEquals(theme:get_color("key"), 0x00FF0001)
+end
+
 function TestImGuiTheme:testSetStyle()
   local theme = ImGuiTheme.new {
     styles = {


### PR DESCRIPTION
Extends the `ImGuiTheme` module to accept functions as style arguments. The `Tween` module is a bit hairy but towards the goal of interacting shallowly with intermediate objects. Define a new tween via `Tween(f, time_provider)`, instantiate it with a start/end/duration and optional callback then just call the result of that as often as you can/want. It's documented in the module header.

Initially I've left in some logging calls that I'll remove before merging. The one integration point implemented is in `TranscriptExporter:open()`. I've temporarily left it a bit explicit to describe the arguments and provide a conversational starting point to figure out where to go with the API - again, before merging back to main.

Fading in the `TranscriptExporter` over 0.2 seconds on `open()`:

https://github.com/user-attachments/assets/a969d01d-a75a-458b-bc58-9fecee02cac2
