### PR TITLE
Transcript Importer

### DIFF
--- a/reascripts/ReaSpeech/source/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ASRActions.lua
@@ -10,6 +10,7 @@ ASRActions = PluginActions {
       self:selected_tracks_button(),
       self:selected_items_button(),
       self:all_items_button(),
+      self:import_button(),
     }
   end
 }
@@ -95,6 +96,17 @@ function ASRActions:all_items_button()
   })
 
   return self._all_items_button
+end
+
+function ASRActions:import_button()
+  if self._import_button then
+    return self._import_button
+  end
+
+  self._import_button = ReaSpeechButton.new({
+    label = "Import Transcript",
+    on_click = function () app.importer:open() end
+  })
 end
 
 function ASRActions.pluralizer(count, suffix)

--- a/reascripts/ReaSpeech/source/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ASRActions.lua
@@ -107,6 +107,8 @@ function ASRActions:import_button()
     label = "Import Transcript",
     on_click = function () app.importer:open() end
   })
+
+  return self._import_button
 end
 
 function ASRActions.pluralizer(count, suffix)

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -68,6 +68,8 @@ function ReaSpeechUI:init()
   self.transcript = Transcript.new()
   self.transcript_ui = TranscriptUI.new { transcript = self.transcript }
 
+  self.importer = TranscriptImporter.new()
+
   self.alert_popup = AlertPopup.new {}
 
   self.react_handlers = self:get_react_handlers()
@@ -127,6 +129,7 @@ function ReaSpeechUI:render_content()
     if self.welcome_ui then
       self.welcome_ui:render()
     end
+    self.importer:render()
     self.controls_ui:render()
     self.actions_ui:render()
     self.transcript_ui:render()
@@ -134,6 +137,11 @@ function ReaSpeechUI:render_content()
   end)
 
   ImGui.PopItemWidth(ctx)
+end
+
+function ReaSpeechUI:load_transcript(transcript)
+  self.transcript = transcript
+  self.transcript_ui = TranscriptUI.new { transcript = self.transcript }
 end
 
 function ReaSpeechUI:submit_request(request)

--- a/reascripts/ReaSpeech/source/Transcript.lua
+++ b/reascripts/ReaSpeech/source/Transcript.lua
@@ -164,6 +164,17 @@ function Transcript:to_json()
   return json.encode(self:to_table())
 end
 
+function Transcript.from_json(json_str)
+  local data = json.decode(json_str)
+  local t = Transcript.new()
+  for _, segment_data in pairs(data.segments) do
+    local segment = TranscriptSegment.from_table(segment_data)
+    t:add_segment(segment)
+  end
+  t:update()
+  return t
+end
+
 function Transcript:update()
   if #self.init_data == 0 then
     self:clear()

--- a/reascripts/ReaSpeech/source/TranscriptImporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptImporter.lua
@@ -1,0 +1,96 @@
+--[[
+
+  TranscriptImporter.lua - Import previously exported Transcript JSON
+
+]]--
+
+TranscriptImporter = Polo {
+  TITLE = 'Import',
+  WIDTH = 650,
+  HEIGHT = 200,
+  BUTTON_WIDTH = 120,
+  INPUT_WIDTH = 120,
+  FILE_WIDTH = 500,
+}
+
+function TranscriptImporter:init()
+  ToolWindow.init(self, {
+    title = self.TITLE,
+    width = self.WIDTH,
+    height = self.HEIGHT,
+    window_flags = 0
+      | ImGui.WindowFlags_AlwaysAutoResize()
+      | ImGui.WindowFlags_NoCollapse()
+      | ImGui.WindowFlags_NoDocking()
+      | ImGui.WindowFlags_TopMost(),
+  })
+
+  self.file_selector = ReaSpeechFileSelector.new({
+    label = 'File - must be JSON previously exported from ReaSpeech.',
+    save = false,
+    button_width = self.BUTTON_WIDTH,
+    input_width = self.FILE_WIDTH
+  })
+
+  self.alert_popup = AlertPopup.new {}
+end
+
+function TranscriptImporter:show_success()
+  self.alert_popup.onclose = function ()
+    self.alert_popup.onclose = nil
+    self:close()
+  end
+  self.alert_popup:show('Import Successful', 'Imported ' .. self.file_selector:value())
+end
+
+function TranscriptImporter:show_error(msg)
+  self.alert_popup:show('Import Failed', msg)
+end
+
+function TranscriptImporter:render_content()
+  self.alert_popup:render()
+
+  self.file_selector:render()
+
+  self:render_separator()
+
+  self:render_buttons()
+end
+
+function TranscriptImporter:render_buttons()
+  -- alternatively we could do a disable-button-if-no-file thing
+  if ImGui.Button(ctx, 'Import', self.BUTTON_WIDTH, 0) then
+    local filepath = self.file_selector:value()
+    if filepath == '' then
+      self:show_error('No file selected')
+      return
+    end
+
+    local success, msg = self:import(filepath)
+    if success then
+      self:show_success()
+    else
+      self:show_error(msg)
+    end
+  end
+
+  ImGui.SameLine(ctx)
+
+  if ImGui.Button(ctx, 'Close', self.BUTTON_WIDTH, 0) then
+    self:close()
+  end
+end
+
+function TranscriptImporter:import(filepath)
+  local file = io.open(filepath, 'r')
+  if not file then
+    return false, 'File not found'
+  end
+
+  local content = file:read('*a')
+  file:close()
+
+  app:load_transcript(Transcript.from_json(content))
+
+  return true
+end

--- a/reascripts/ReaSpeech/source/TranscriptSegment.lua
+++ b/reascripts/ReaSpeech/source/TranscriptSegment.lua
@@ -65,6 +65,41 @@ TranscriptSegment.from_whisper = function(segment, item, take)
   return result
 end
 
+TranscriptSegment.from_table = function(data)
+  local segment_data = {}
+  local words = data.words
+  local item, take
+  data.words = nil
+
+  if words then
+    local transcript_words = {}
+    for _, word in pairs(words) do
+      table.insert(transcript_words, TranscriptWord.from_table(word))
+    end
+    data.words = transcript_words
+  end
+
+  for k, v in pairs(data) do
+    if k == 'item' then
+      item = ReaUtil.get_item_by_guid(v) or {}
+    elseif k == 'take' then
+      take = reaper.GetMediaItemTakeByGUID(0, v) or {}
+    --luacheck: ignore
+    elseif k == 'words' then
+      -- empty branch is okay! already handled
+    else
+      segment_data[k] = v
+    end
+  end
+
+  return TranscriptSegment.new {
+    data = segment_data,
+    item = item,
+    take = take,
+    words = data.words
+  }
+end
+
 TranscriptSegment.default_hide = function(column)
   return Transcript.DEFAULT_HIDE[column] or false
 end

--- a/reascripts/ReaSpeech/source/TranscriptSegment.lua
+++ b/reascripts/ReaSpeech/source/TranscriptSegment.lua
@@ -212,6 +212,9 @@ function TranscriptSegment:to_table()
       table.insert(result['words'], word:to_table())
     end
   end
+
+  result.item = ReaUtil.get_item_info(self.item, 'GUID')
+  result.take = ReaUtil.get_take_info(self.take, 'GUID')
   return result
 end
 

--- a/reascripts/ReaSpeech/source/TranscriptWord.lua
+++ b/reascripts/ReaSpeech/source/TranscriptWord.lua
@@ -35,6 +35,15 @@ function TranscriptWord:to_table()
   }
 end
 
+function TranscriptWord.from_table(data)
+  return TranscriptWord.new {
+    word = data.word,
+    start = data.start,
+    end_ = data['end'],
+    probability = data.probability,
+  }
+end
+
 function TranscriptWord:select_in_timeline(offset)
   offset = offset or 0
   local start = self.start + offset

--- a/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
@@ -29,6 +29,7 @@ require('source/TranscriptAnnotations')
 require('source/TranscriptAnnotationsUI')
 require('source/TranscriptEditor')
 require('source/TranscriptExporter')
+require('source/TranscriptImporter')
 require('source/TranscriptUI')
 require('source/WhisperLanguages')
 

--- a/reascripts/common/libs/ReaUtil.lua
+++ b/reascripts/common/libs/ReaUtil.lua
@@ -87,3 +87,12 @@ function ReaUtil.get_take_info(take, param, default)
   return ReaUtil._get_object_info(reaper.GetSetMediaItemTakeInfo_String, take, param)
     or default
 end
+
+function ReaUtil.get_item_by_guid(guid)
+  for item in ReaIter.each_media_item() do
+    if ReaUtil.get_item_info(item, 'GUID') == guid then
+      return item
+    end
+  end
+  return nil
+end

--- a/reascripts/common/libs/ReaUtil.lua
+++ b/reascripts/common/libs/ReaUtil.lua
@@ -71,3 +71,19 @@ function ReaUtil.get_source_path(take)
   end
   return nil
 end
+
+function ReaUtil._get_object_info(getter_f, object, param)
+  local result, value = getter_f(object, param, '', false)
+
+  return result and value or nil
+end
+
+function ReaUtil.get_item_info(item, param, default)
+  return ReaUtil._get_object_info(reaper.GetSetMediaItemInfo_String, item, param)
+    or default
+end
+
+function ReaUtil.get_take_info(take, param, default)
+  return ReaUtil._get_object_info(reaper.GetSetMediaItemTakeInfo_String, take, param)
+    or default
+end

--- a/reascripts/common/tests/TestReaUtil.lua
+++ b/reascripts/common/tests/TestReaUtil.lua
@@ -188,6 +188,32 @@ function TestReaUtil:testGetObjectInfoDefaults()
   lu.assertEquals(ReaUtil.get_take_info('duh', 'GUID', 'derpfault'), 'derpfault')
 end
 
+function TestReaUtil:testGetItemByGUID()
+  reaper.CountMediaItems = function() return 2 end
+  reaper.GetMediaItem = function(_, idx)
+    if idx == 0 then
+      return "item1"
+    elseif idx == 1 then
+      return "item2"
+    end
+  end
+
+  ReaIter.each_media_item = ReaIter._make_iterator(reaper.CountMediaItems, reaper.GetMediaItem)
+
+  reaper.GetSetMediaItemInfo_String = function(item, param, _, is_set)
+    lu.assertIsFalse(is_set)
+    if item == 'item1' and param == "GUID" then
+      return true, "item1_guid"
+    elseif item == 'item2' and param == "GUID" then
+      return true, "item2_guid"
+    end
+  end
+
+  lu.assertEquals(ReaUtil.get_item_by_guid("item1_guid"), "item1")
+  lu.assertEquals(ReaUtil.get_item_by_guid("item2_guid"), "item2")
+  lu.assertIsNil(ReaUtil.get_item_by_guid("derp"))
+end
+
 --
 
 os.exit(lu.LuaUnit.run())

--- a/reascripts/common/tests/TestReaUtil.lua
+++ b/reascripts/common/tests/TestReaUtil.lua
@@ -143,6 +143,51 @@ function TestReaUtil:testTrackGuids()
   lu.assertEquals(guids[1][2], "track")
 end
 
+function TestReaUtil:testGetItemInfo()
+  reaper.GetSetMediaItemInfo_String = function(item, param, _, is_set)
+    lu.assertIsFalse(is_set)
+    if item == 'item' and param == "GUID" then
+      return true, "item_guid"
+    end
+  end
+
+  lu.assertIsNil(ReaUtil.get_item_info("derp", "GUID"))
+  lu.assertEquals(ReaUtil.get_item_info("item", "GUID"), "item_guid")
+end
+
+function TestReaUtil:testGetTakeInfo()
+  reaper.GetSetMediaItemTakeInfo_String = function(take, param, _, is_set)
+    lu.assertIsFalse(is_set)
+    if take == 'take' and param == "GUID" then
+      return true, "take_guid"
+    end
+  end
+
+  lu.assertIsNil(ReaUtil.get_take_info("derp", "GUID"))
+  lu.assertEquals(ReaUtil.get_take_info("take", "GUID"), "take_guid")
+end
+
+function TestReaUtil:testGetObjectInfoDefaults()
+  reaper.GetSetMediaItemInfo_String = function(item, param, _, is_set)
+    lu.assertIsFalse(is_set)
+    if item == 'item' and param == "GUID" then
+      return true, "item_guid"
+    end
+  end
+
+  reaper.GetSetMediaItemTakeInfo_String = function(take, param, _, is_set)
+    lu.assertIsFalse(is_set)
+    if take == 'take' and param == "GUID" then
+      return true, "take_guid"
+    end
+  end
+
+  lu.assertEquals(ReaUtil.get_item_info('item', 'GUID', 'derpfault'), 'item_guid')
+  lu.assertEquals(ReaUtil.get_item_info('duh', 'GUID', 'derpfault'), 'derpfault')
+  lu.assertEquals(ReaUtil.get_take_info('take', 'GUID', 'derpfault'), 'take_guid')
+  lu.assertEquals(ReaUtil.get_take_info('duh', 'GUID', 'derpfault'), 'derpfault')
+end
+
 --
 
 os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
Adds the ability to import a JSON transcript previously exported by ReaSpeech.

This adds a button ("Import Transcript") next to the "Process..." buttons in the main interface. The popup has a simple file selector, and when "Import" is clicked ReaSpeech will attempt to load the JSON content from the file and and re-attach whichever media items/takes were associated with each segment found.

I'm thinking of this as a stepping stone to some kind of autosave system. Like...maybe a dropdown somewhere allowing a quick revert to the last [configurable x] invocations (clicks on a "process" button). 🤔🤔🤔🤔

Opening the popup and importing some JSON:

https://github.com/user-attachments/assets/b23044aa-6828-470f-abdb-13adbcfefa31

