### PR TITLE
Introduce a Trap library in place of app:trap

### DIFF
--- a/reascripts/ReaSpeech/Makefile
+++ b/reascripts/ReaSpeech/Makefile
@@ -4,7 +4,7 @@ LUA54=lua5.4
 LUAC54=luac5.4
 LUACHECK=luacheck
 
-LIBS=ExecProcess.lua ImGuiTheme.lua Polo.lua ReaIter.lua ReaUtil.lua Storage.lua TableUtils.lua Tempfile.lua
+LIBS=ExecProcess.lua ImGuiTheme.lua Polo.lua ReaIter.lua ReaUtil.lua Storage.lua TableUtils.lua Tempfile.lua Trap.lua
 VENDOR=json.lua url.lua
 
 source:=$(wildcard libs/*.lua source/*.lua source/include/*.lua)

--- a/reascripts/ReaSpeech/libs/ToolWindow.lua
+++ b/reascripts/ReaSpeech/libs/ToolWindow.lua
@@ -212,16 +212,14 @@ function ToolWindow.render(o)
     o:open()
   end
 
-  local trap = function(f) return app:trap(f) end
-
   local f = function()
     state.theme:wrap(o.ctx, function()
       ToolWindow._render_window(o)
-    end, trap)
+    end, Trap)
   end
 
   if state.font then
-    Fonts.wrap(ctx, Fonts.main, f, trap)
+    Fonts.wrap(ctx, Fonts.main, f, Trap)
   else
     f()
   end
@@ -241,7 +239,7 @@ function ToolWindow._render_window(o)
   ImGui.SetNextWindowSize(o.ctx, state.width, state.height, ImGui.Cond_FirstUseEver())
   local visible, open = state.begin_f(o.ctx, state.title, true, state.window_flags)
   if visible then
-    app:trap(function ()
+    Trap(function ()
       if o.render_content then
         o:render_content()
       end

--- a/reascripts/ReaSpeech/source/ASRControls.lua
+++ b/reascripts/ReaSpeech/source/ASRControls.lua
@@ -141,7 +141,7 @@ function ASRControls:init_simple_layout()
 
     render_column = function (column)
       ImGui.PushItemWidth(ctx, column.width)
-      app:trap(function () renderers[column.num](self, column) end)
+      Trap(function () renderers[column.num](self, column) end)
       ImGui.PopItemWidth(ctx)
     end
   }
@@ -165,7 +165,7 @@ function ASRControls:init_advanced_layout()
       ImGui.PushItemWidth(ctx, column.width)
       for row, renderer in ipairs(renderers[column.num]) do
         if row > 1 then ImGui.Spacing(ctx) end
-        app:trap(function () renderer(self, column) end)
+        Trap(function () renderer(self, column) end)
       end
       ImGui.PopItemWidth(ctx)
     end

--- a/reascripts/ReaSpeech/source/ColumnLayout.lua
+++ b/reascripts/ReaSpeech/source/ColumnLayout.lua
@@ -65,6 +65,6 @@ end
 
 function ColumnLayout:_with_group(f)
   ImGui.BeginGroup(ctx)
-  app:trap(f)
+  Trap(f)
   ImGui.EndGroup(ctx)
 end

--- a/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
@@ -13,7 +13,7 @@ end
 function ReaSpeechActionsUI:render()
   local disable_if = self.disabler
   local progress
-  app:trap(function ()
+  Trap(function ()
     progress = self.worker:progress()
   end)
 

--- a/reascripts/ReaSpeech/source/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechMain.lua
@@ -23,7 +23,7 @@ end
 function ReaSpeechMain:loop()
   return function()
     if app:presenting() or app:is_open() then
-      app:trap(function() app:react() end)
+      Trap(function() app:react() end)
       reaper.defer(self:loop())
     end
   end

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -30,7 +30,7 @@ function ReaSpeechUI:init()
 
   Logging.init(self, 'ReaSpeechUI')
 
-  self.onerror = function (e)
+  Trap.on_error = function (e)
     self:log(e)
   end
 
@@ -79,13 +79,9 @@ ReaSpeechUI.config_flags = function ()
   return ImGui.ConfigFlags_DockingEnable()
 end
 
-function ReaSpeechUI:trap(f)
-  return xpcall(f, self.onerror)
-end
-
 function ReaSpeechUI:react()
   for _, handler in pairs(self.react_handlers) do
-    self:trap(handler)
+    Trap(handler)
   end
 end
 
@@ -125,7 +121,7 @@ function ReaSpeechUI:render_content()
 
   ImGui.PushItemWidth(ctx, self.ITEM_WIDTH)
 
-  self:trap(function ()
+  Trap(function ()
     if self.welcome_ui then
       self.welcome_ui:render()
     end

--- a/reascripts/ReaSpeech/source/ReaSpeechWelcomeUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWelcomeUI.lua
@@ -80,7 +80,7 @@ end
 
 function ReaSpeechWelcomeUI:render_heading(text)
   ImGui.PushFont(ctx, Fonts.bold)
-  app:trap(function ()
+  Trap(function ()
     ImGui.Dummy(ctx, self.WIDTH, self.HEADING_MARGIN)
     ImGui.SetCursorPosX(ctx, self.PADDING)
     ImGui.Text(ctx, text)

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -21,7 +21,7 @@ end
 function ReaSpeechWidget:render(...)
   ImGui.PushID(self.ctx, self.widget_id)
   local args = ...
-  app:trap(function()
+  Trap(function()
     self.renderer(self, args)
   end)
   ImGui.PopID(self.ctx)
@@ -164,7 +164,7 @@ ReaSpeechCombo.renderer = function (self)
   local combo_flags = ImGui.ComboFlags_HeightLarge()
 
   if ImGui.BeginCombo(self.ctx, imgui_label, item_label, combo_flags) then
-    app:trap(function()
+    Trap(function()
       for _, item in pairs(options.items) do
         local is_selected = (item == self:value())
         if ImGui.Selectable(self.ctx, options.item_labels[item], is_selected) then
@@ -200,7 +200,7 @@ ReaSpeechTabBar.renderer = function (self)
   if ImGui.BeginTabBar(self.ctx, 'TabBar') then
     for _, tab in pairs(self.options.tabs) do
       if ImGui.BeginTabItem(self.ctx, tab.label) then
-        app:trap(function()
+        Trap(function()
           self:set(tab.key)
         end)
         ImGui.EndTabItem(self.ctx)
@@ -242,7 +242,7 @@ ReaSpeechButtonBar.new = function (options)
   local with_button_color = function (selected, f)
     if selected then
       ImGui.PushStyleColor(o.ctx, ImGui.Col_Button(), Theme.colors.dark_gray_translucent)
-      app:trap(f)
+      Trap(f)
       ImGui.PopStyleColor(o.ctx)
     else
       f()
@@ -305,7 +305,7 @@ ReaSpeechButton.renderer = function(self)
 
   disable_if(options.disabled, function()
     if ImGui.Button(self.ctx, options.label, options.width) then
-      app:trap(options.on_click)
+      Trap(options.on_click)
     end
   end)
 end
@@ -436,7 +436,7 @@ ReaSpeechListBox.renderer = function(self)
 
   local needs_update = false
   if ImGui.BeginListBox(self.ctx, imgui_label) then
-    app:trap(function()
+    Trap(function()
       local current = self:value()
       local new_value = {}
       for i, item in ipairs(options.items) do
@@ -444,7 +444,7 @@ ReaSpeechListBox.renderer = function(self)
         local is_selected = current[item]
         local label = options.item_labels[item]
         ImGui.PushID(ctx, 'item' .. i)
-        app:trap(function()
+        Trap(function()
           local result, now_selected = ImGui.Selectable(self.ctx, label, is_selected)
 
           if result and is_selected ~= now_selected then

--- a/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWorker.lua
@@ -21,7 +21,7 @@ function ReaSpeechWorker:react()
   local time = reaper.time_precise()
   local fs = self:interval_functions()
   for i = 1, #fs do
-    app:trap(function ()
+    Trap(function ()
       fs[i]:react(time)
     end)
   end

--- a/reascripts/ReaSpeech/source/SampleMultipleUploadControls.lua
+++ b/reascripts/ReaSpeech/source/SampleMultipleUploadControls.lua
@@ -33,7 +33,7 @@ function SampleMultipleUploadControls:init_layout()
 
     render_column = function (column)
       ImGui.PushItemWidth(ctx, column.width)
-      app:trap(function () self:render_controls() end)
+      Trap(function () self:render_controls() end)
       ImGui.PopItemWidth(ctx)
     end
   }

--- a/reascripts/ReaSpeech/source/SettingsControls.lua
+++ b/reascripts/ReaSpeech/source/SettingsControls.lua
@@ -40,7 +40,7 @@ function SettingsControls:init_layout()
 
     render_column = function (column)
       ImGui.PushItemWidth(ctx, column.width)
-      app:trap(function () renderers[column.num](self, column) end)
+      Trap(function () renderers[column.num](self, column) end)
       ImGui.PopItemWidth(ctx)
     end
   }

--- a/reascripts/ReaSpeech/source/TranscriptAnnotationsUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptAnnotationsUI.lua
@@ -131,7 +131,7 @@ function TranscriptAnnotationTypes:selected_type()
 end
 
 function TranscriptAnnotationTypes:render_type_options(options)
-  app:trap(function()
+  Trap(function()
     local type = self:selected_type()
 
     if type then

--- a/reascripts/ReaSpeech/source/TranscriptEditor.lua
+++ b/reascripts/ReaSpeech/source/TranscriptEditor.lua
@@ -116,7 +116,7 @@ function TranscriptEditor:render_word_navigation()
   local disable_if = ReaUtil.disabler(ctx, app.onerror)
 
   ImGui.PushButtonRepeat(ctx, true)
-  app:trap(function ()
+  Trap(function ()
     if ImGui.ArrowButton(ctx, '##left', ImGui.Dir_Left()) then
       self:edit_word(self.editing.word_index - 1)
     end
@@ -171,7 +171,7 @@ function TranscriptEditor:render_words()
     if self.editing.word_index ~= i then
       ImGui.PushStyleColor(ctx, ImGui.Col_Button(), 0xffffff33)
     end
-    app:trap(function()
+    Trap(function()
       if ImGui.Button(ctx, word.word .. '##' .. i) then
         edit_requested = i
       end
@@ -233,7 +233,7 @@ function TranscriptEditor:render_score_input()
     ImGui.PushStyleColor(ctx, ImGui.Col_SliderGrab(), color)
     ImGui.PushStyleColor(ctx, ImGui.Col_SliderGrabActive(), color)
   end
-  app:trap(function ()
+  Trap(function ()
     local rv, value = ImGui.SliderDouble(ctx, 'score', self.editing.word.probability, 0, 1)
     if rv then
       self.editing.word.probability = value
@@ -281,10 +281,10 @@ function TranscriptEditor:render_zoom_combo()
   ImGui.Text(ctx, "zoom to")
   ImGui.SameLine(ctx)
   ImGui.PushItemWidth(ctx, self.BUTTON_WIDTH)
-  app:trap(function()
+  Trap(function()
     disable_if(not self.sync_time_selection, function()
       if ImGui.BeginCombo(ctx, "##zoom_level", self.zoom_level) then
-        app:trap(function()
+        Trap(function()
           for _, zoom in pairs(self.ZOOM_LEVEL) do
             if ImGui.Selectable(ctx, zoom.description, self.zoom_level == zoom.value) then
               self.zoom_level = zoom.value

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -128,7 +128,7 @@ function TranscriptExporterFormats:render_combo(width)
   ImGui.Text(ctx, 'Format')
   ImGui.SetNextItemWidth(ctx, width)
   if ImGui.BeginCombo(ctx, "##format", self.selected_format_key) then
-    app:trap(function()
+    Trap(function()
       for _, format in pairs(self.formatters) do
         local is_selected = self.selected_format_key == format.key
         if ImGui.Selectable(ctx, format.key, is_selected) then
@@ -171,7 +171,7 @@ function TranscriptExporterFormats:selected_format()
 end
 
 function TranscriptExporterFormats:render_format_options(options)
-  app:trap(function()
+  Trap(function()
     local format = self:selected_format()
 
     if format then
@@ -290,7 +290,7 @@ function TranscriptExportFormat.options_csv(options)
   end
 
   if ImGui.BeginCombo(ctx, 'Delimiter', selected_delimiter.name) then
-    app:trap(function()
+    Trap(function()
       for _, delimiter in ipairs(delimiters) do
         local is_selected = options.delimiter == delimiter.char
         if ImGui.Selectable(ctx, delimiter.name, is_selected) then

--- a/reascripts/ReaSpeech/source/TranscriptSegment.lua
+++ b/reascripts/ReaSpeech/source/TranscriptSegment.lua
@@ -186,7 +186,7 @@ function TranscriptSegment:get_file(include_extensions)
   include_extensions = include_extensions or false
 
   local file = ''
-  app:trap(function ()
+  Trap(function ()
     local source = reaper.GetMediaItemTake_Source(self.take)
     if source then
       local source_path = reaper.GetMediaSourceFileName(source)

--- a/reascripts/ReaSpeech/source/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptUI.lua
@@ -136,7 +136,7 @@ end
 function TranscriptUI:render_search(column)
   ImGui.SetCursorPosX(ctx, ImGui.GetWindowWidth(ctx) - column.width - self.ACTIONS_MARGIN)
   ImGui.PushItemWidth(ctx, column.width)
-  app:trap(function()
+  Trap(function()
     local search_changed, search = ImGui.InputTextWithHint(ctx, '##search', 'Search', self.transcript.search)
     if search_changed then
       self:handle_search(search)
@@ -164,7 +164,7 @@ function TranscriptUI:render_table()
 
   local ok = ImGui.BeginTable(ctx, "results", num_columns, self.table_flags(true))
   if ok then
-    app:trap(function ()
+    Trap(function ()
       ImGui.TableSetupColumn(ctx, "##actions", ImGui.TableColumnFlags_NoSort(), 20)
 
       for _, column in pairs(columns) do

--- a/reascripts/ReaSpeech/source/Widgets.lua
+++ b/reascripts/ReaSpeech/source/Widgets.lua
@@ -71,9 +71,9 @@ function Widgets.tooltip(text)
      not ImGui.BeginTooltip(ctx)
   then return end
 
-  app:trap(function()
+  Trap(function()
     ImGui.PushTextWrapPos(ctx, ImGui.GetFontSize(ctx) * 42)
-    app:trap(function()
+    Trap(function()
       ImGui.Text(ctx, text)
     end)
     ImGui.PopTextWrapPos(ctx)

--- a/reascripts/ReaSpeech/tests/TestCSVWriter.lua
+++ b/reascripts/ReaSpeech/tests/TestCSVWriter.lua
@@ -6,6 +6,7 @@ local lu = require('luaunit')
 
 require('mock_reaper')
 require('Polo')
+require('Trap')
 require('source/CSVWriter')
 require('source/Transcript')
 require('source/TranscriptSegment')
@@ -18,8 +19,6 @@ reaper.GetMediaSourceFileName = function (source) return source.fileName end
 TestCSVWriter = {}
 
 function TestCSVWriter:setUp()
-  function app:trap(f) return xpcall(f, function(e) print(tostring(e)) end) end
-
   reaper.__test_setUp()
 end
 

--- a/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/tests/TestReaSpeechUI.lua
@@ -6,6 +6,7 @@ require('ImGuiTheme')
 require('Polo')
 require('ReaUtil')
 require('Storage')
+require('Trap')
 require('mock_reaper')
 require('ReaIter')
 

--- a/reascripts/ReaSpeech/tests/TestSRTWriter.lua
+++ b/reascripts/ReaSpeech/tests/TestSRTWriter.lua
@@ -6,6 +6,7 @@ local lu = require('luaunit')
 
 require('mock_reaper')
 require('Polo')
+require('Trap')
 require('source/SRTWriter')
 require('source/Transcript')
 require('source/TranscriptSegment')
@@ -18,8 +19,6 @@ reaper.GetMediaSourceFileName = function (source) return source.fileName end
 TestSRTWriter = {}
 
 function TestSRTWriter:setUp()
-  function app:trap(f) return xpcall(f, function(e) print(tostring(e)) end) end
-
   reaper.__test_setUp()
 end
 

--- a/reascripts/ReaSpeech/tests/TestToolWindow.lua
+++ b/reascripts/ReaSpeech/tests/TestToolWindow.lua
@@ -6,6 +6,7 @@ require('mock_reaper')
 require('ImGuiTheme')
 require('Polo')
 require('Storage')
+require('Trap')
 require('libs/ToolWindow')
 require('source/Logging')
 require('source/Tween')
@@ -183,10 +184,6 @@ function TestToolWindow:testClose()
   o:close()
   lu.assertEquals(o:is_open(), false)
 end
-
-app = {
-  trap = function(self, f) return xpcall(f, function(e) print(tostring(e)) end) end
-}
 
 function TestToolWindow:testRender()
   ImGui = ImGui or {}

--- a/reascripts/ReaSpeech/tests/TestTranscript.lua
+++ b/reascripts/ReaSpeech/tests/TestTranscript.lua
@@ -9,6 +9,7 @@ require('mock_reaper')
 require('Polo')
 require('ReaIter')
 require('ReaUtil')
+require('Trap')
 require('source/Transcript')
 require('source/TranscriptSegment')
 require('source/TranscriptWord')
@@ -36,8 +37,6 @@ TestTranscript = {
 }
 
 function TestTranscript:setUp()
-  function app:trap(f) return xpcall(f, function(e) print(tostring(e)) end) end
-
   reaper.__test_setUp()
 end
 

--- a/reascripts/ReaSpeech/tests/TestTranscriptAnnotations.lua
+++ b/reascripts/ReaSpeech/tests/TestTranscriptAnnotations.lua
@@ -1,11 +1,5 @@
 package.path = '../common/libs/?.lua;../common/vendor/?.lua;' .. package.path
 
-app = {
-  trap = function(self, f)
-    return xpcall(f, function(e) print(tostring(e)) end)
-  end
-}
-
 local lu = require('luaunit')
 
 require('json')
@@ -13,6 +7,7 @@ require('mock_reaper')
 require('Polo')
 require('ReaUtil')
 require('Storage')
+require('Trap')
 require('source/ColumnLayout')
 require('source/Logging')
 require('source/ReaSpeechUI')

--- a/reascripts/common/libs/Trap.lua
+++ b/reascripts/common/libs/Trap.lua
@@ -1,0 +1,25 @@
+--[[
+
+  Trap.lua - Error handling wrapper for Lua exceptions
+
+  Usage:
+
+    Trap.on_error = function (e)
+      reaper.ShowConsoleMsg(tostring(e) .. "\n")
+    end
+
+    Trap(function () error("This is an error") end)
+
+]]--
+
+Trap = {
+  on_error = function (e)
+    print(tostring(e))
+  end,
+
+  __call = function (self, f)
+    return xpcall(f, self.on_error)
+  end
+}
+
+setmetatable(Trap, Trap)


### PR DESCRIPTION
Introduce a `Trap` callable object to use instead of `app:trap`. This offers a few advantages:

- Simplifies runtime dependencies, since libraries do not need to depend on an `app` global
- Reduces the amount of overhead due to indirection and closure creation