### PR TITLE
Remove tqdm calls for faster-whisper

### DIFF
--- a/app/faster_whisper/core.py
+++ b/app/faster_whisper/core.py
@@ -27,7 +27,6 @@ from threading import Lock
 from typing import Union, BinaryIO
 
 import torch
-import tqdm
 import whisper
 from faster_whisper import WhisperModel
 
@@ -64,14 +63,12 @@ def transcribe(audio, asr_options, output):
         segments = []
         text = ""
         segment_generator, info = model.transcribe(audio, beam_size=5, **options_dict)
-        with tqdm.tqdm(total=round(info.duration), unit='sec') as tqdm_pbar:
-            for segment in segment_generator:
-                segment_dict = segment._asdict()
-                if segment.words:
-                    segment_dict["words"] = [word._asdict() for word in segment.words]
-                segments.append(segment_dict)
-                text = text + segment.text
-                tqdm_pbar.update(segment.end - segment.start)
+        for segment in segment_generator:
+            segment_dict = segment._asdict()
+            if segment.words:
+                segment_dict["words"] = [word._asdict() for word in segment.words]
+            segments.append(segment_dict)
+            text = text + segment.text
         result = {
             "language": options_dict.get("language", info.language),
             "segments": segments,


### PR DESCRIPTION
With the faster-whisper upgrade, tqdm is getting called automatically to update progress state. This was previously not the case, so we were doing it ourselves. Now, progress is getting double-logged, and sometimes (presumably due to the VAD filter) it is causing the progress bar to jump back and forth.