### PR TITLE
Add help tooltips to ASR controls

### DIFF
--- a/reascripts/ReaSpeech/source/ASRControls.lua
+++ b/reascripts/ReaSpeech/source/ASRControls.lua
@@ -10,6 +10,11 @@ ASRControls = PluginControls {
   DEFAULT_LANGUAGE = '',
   DEFAULT_MODEL_NAME = 'small',
 
+  HELP_MODEL = 'Model to use for transcription. Larger models provide better accuracy but use more resources.',
+  HELP_LANGUAGE = 'Language spoken in audio. Set to "Detect" to auto-detect language.',
+  HELP_PRESERVED_WORDS = 'Comma-separated list of words to preserve in transcript. Example: Jane Doe, CyberCorp',
+  HELP_VAD = 'Enable Voice Activity Detection (VAD) to filter out silence.',
+
   tabs = function(self)
     return {
       ReaSpeechPlugins.tab('asr-simple', 'Simple',
@@ -45,6 +50,7 @@ function ASRControls:init()
   self.language = ReaSpeechCombo.new {
     state = self.settings.language,
     label = 'Language',
+    help_text = self.HELP_LANGUAGE,
     items = WhisperLanguages.LANGUAGE_CODES,
     item_labels = WhisperLanguages.LANGUAGES
   }
@@ -58,29 +64,28 @@ function ASRControls:init()
 
   self.hotwords = ReaSpeechTextInput.new {
     state = self.settings.hotwords,
-    label = 'Preserved Words'
+    label = 'Preserved Words',
+    help_text = self.HELP_PRESERVED_WORDS
   }
 
   self.initial_prompt = ReaSpeechTextInput.new {
     state = self.settings.initial_prompt,
-    label = 'Preserved Words'
-  }
-
-  self.model_name = ReaSpeechTextInput.new {
-    state = self.settings.model_name,
-    label = 'Model Name'
+    label = 'Preserved Words',
+    help_text = self.HELP_PRESERVED_WORDS
   }
 
   self.vad_filter = ReaSpeechCheckbox.new {
     state = self.settings.vad_filter,
     label_long = 'Voice Activity Detection',
     label_short = 'VAD',
+    help_text = self.HELP_VAD,
     width_threshold = ReaSpeechControlsUI.NARROW_COLUMN_WIDTH
   }
 
-  self.model_combo = ReaSpeechCombo.new {
+  self.model_name = ReaSpeechCombo.new {
     state = self.settings.model_name,
     label = 'Model',
+    help_text = self.HELP_MODEL,
     items = WhisperModels.get_model_names(self.asr_engine),
     item_labels = self:get_model_labels(),
   }
@@ -188,7 +193,7 @@ function ASRControls:render_language(column)
 end
 
 function ASRControls:render_model()
-  self.model_combo:render()
+  self.model_name:render()
 end
 
 function ASRControls:render_hotwords()

--- a/reascripts/ReaSpeech/source/Icons.lua
+++ b/reascripts/ReaSpeech/source/Icons.lua
@@ -80,3 +80,29 @@ function Icons.stop(dl, x, y, w, h, color)
     y + h * 0.7,
     color)
 end
+
+function Icons.info(dl, x, y, w, h, color)
+  ImGui.DrawList_AddCircle(
+    dl,
+    x + w * 0.5,
+    y + h * 0.5,
+    w * 0.5,
+    color,
+    20)
+  -- Dot of the i
+  ImGui.DrawList_AddRectFilled(
+    dl,
+    x + w * 0.46,
+    y + h * 0.3,
+    x + w * 0.54,
+    y + h * 0.35,
+    color)
+  -- Body of the i
+  ImGui.DrawList_AddRectFilled(
+    dl,
+    x + w * 0.46,
+    y + h * 0.45,
+    x + w * 0.54,
+    y + h * 0.7,
+    color)
+end

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -5,6 +5,7 @@
 ]]--
 
 ReaSpeechWidget = Polo {
+  HELP_ICON_SIZE = 15,
 }
 
 function ReaSpeechWidget:init()
@@ -25,6 +26,26 @@ function ReaSpeechWidget:render(...)
     self.renderer(self, args)
   end)
   ImGui.PopID(self.ctx)
+end
+
+function ReaSpeechWidget:render_help_icon()
+  local options = self.options
+  local size = self.HELP_ICON_SIZE
+  Widgets.icon(Icons.info, '##help-text', size, size, options.help_text, 0xffffffa0, 0xffffffff)
+end
+
+function ReaSpeechWidget:render_label(label)
+  local options = self.options
+  label = label or options.label
+
+  ImGui.Text(self.ctx, label)
+
+  if label ~= '' and options.help_text then
+    ImGui.SameLine(ctx)
+    self:render_help_icon()
+  end
+
+  ImGui.Dummy(self.ctx, 0, 0)
 end
 
 function ReaSpeechWidget:value()
@@ -82,6 +103,12 @@ ReaSpeechCheckbox.renderer = function (self, column)
 
   local rv, value = ImGui.Checkbox(self.ctx, label, self:value())
 
+  if options.help_text then
+    ImGui.SameLine(ctx)
+    ImGui.SetCursorPosY(ctx, ImGui.GetCursorPosY(ctx) + 7)
+    self:render_help_icon()
+  end
+
   if rv then
     self:set(value)
     options.changed_handler(value)
@@ -116,8 +143,7 @@ end
 ReaSpeechTextInput.renderer = function (self)
   local options = self.options
 
-  ImGui.Text(self.ctx, options.label)
-  ImGui.Dummy(self.ctx, 0, 0)
+  self:render_label()
 
   local imgui_label = ("##%s"):format(options.label)
 
@@ -156,8 +182,7 @@ end
 ReaSpeechCombo.renderer = function (self)
   local options = self.options
 
-  ImGui.Text(self.ctx, options.label)
-  ImGui.Dummy(self.ctx, 0, 0)
+  self:render_label()
 
   local imgui_label = ("##%s"):format(options.label)
   local item_label = options.item_labels[self:value()] or ""
@@ -259,8 +284,7 @@ ReaSpeechButtonBar.new = function (options)
 
     render_column = function (column)
       local bar_label = column.num == 1 and options.label or ""
-      ImGui.Text(o.ctx, bar_label)
-      ImGui.Dummy(o.ctx, 0, 0)
+      o:render_label(bar_label)
 
       local button_label, model_name = table.unpack(options.buttons[column.num])
       with_button_color(o:value() == model_name, function ()
@@ -429,8 +453,7 @@ end
 ReaSpeechListBox.renderer = function(self)
   local options = self.options
 
-  ImGui.Text(self.ctx, options.label)
-  ImGui.Dummy(self.ctx, 0, 0)
+  self:render_label()
 
   local imgui_label = ("##%s"):format(options.label)
 

--- a/reascripts/ReaSpeech/source/Widgets.lua
+++ b/reascripts/ReaSpeech/source/Widgets.lua
@@ -6,11 +6,14 @@
 
 Widgets = {}
 
-function Widgets.icon(icon, id, w, h, tooltip, color)
+function Widgets.icon(icon, id, w, h, tooltip, color, hover_color)
   assert(tooltip, 'missing tooltip for icon')
   color = color or 0xffffffff
   local x, y = ImGui.GetCursorScreenPos(ctx)
   local rv = ImGui.InvisibleButton(ctx, id, w, h)
+  if ImGui.IsItemHovered(ctx) then
+    color = hover_color or color
+  end
   local dl = ImGui.GetWindowDrawList(ctx)
   icon(dl, x, y, w, h, color)
   Widgets.tooltip(tooltip)


### PR DESCRIPTION
Add help icons that show tooltips with brief documentation. Closes #96 

- Added help_text option to ReaSpeechWidgets
- Added "info" icon
- Added hover color parameter to Widgets.icon
- Wrote help text for some ASR controls