### PR TITLE
Use ImGui's ListClipper to avoid low-fps hell

### DIFF
--- a/reascripts/ReaSpeech/source/Transcript.lua
+++ b/reascripts/ReaSpeech/source/Transcript.lua
@@ -13,7 +13,11 @@ Transcript = Polo {
 
   init = function(self)
     self:clear()
-  end
+  end,
+
+  __len = function(self)
+    return #self.data
+  end,
 }
 
 Transcript.calculate_offset = function (item, take)
@@ -82,6 +86,10 @@ end
 
 function Transcript:has_segments()
   return #self.init_data > 0
+end
+
+function Transcript:get_segment(row)
+  return self.data[row]
 end
 
 function Transcript:get_segments()

--- a/reascripts/ReaSpeech/source/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptUI.lua
@@ -57,6 +57,14 @@ function TranscriptUI:init()
   self:init_layouts()
 end
 
+function TranscriptUI:_clipper()
+  if not ImGui.ValidatePtr(self.clipper, 'ImGui_ListClipper*') then
+    self.clipper = ImGui.CreateListClipper(ctx)
+  end
+
+  return self.clipper
+end
+
 function TranscriptUI:init_layouts()
   local renderers = {
     self.render_annotations_button,
@@ -162,8 +170,7 @@ function TranscriptUI:render_table()
   local columns = self.transcript:get_columns()
   local num_columns = #columns + 1
 
-  local ok = ImGui.BeginTable(ctx, "results", num_columns, self.table_flags(true))
-  if ok then
+  if ImGui.BeginTable(ctx, "results", num_columns, self.table_flags(true)) then
     Trap(function ()
       ImGui.TableSetupColumn(ctx, "##actions", ImGui.TableColumnFlags_NoSort(), 20)
 
@@ -182,17 +189,28 @@ function TranscriptUI:render_table()
       end
 
       ImGui.TableSetupScrollFreeze(ctx, 0, 1)
-      ImGui.TableHeadersRow(ctx)
 
-      self:sort_table()
+      local clipper = self:_clipper()
 
-      for index, segment in pairs(self.transcript:get_segments()) do
-        ImGui.TableNextRow(ctx)
-        ImGui.TableNextColumn(ctx)
-        self:render_segment_actions(segment, index)
-        for _, column in pairs(columns) do
-          ImGui.TableNextColumn(ctx)
-          self:render_table_cell(segment, column)
+      ImGui.ListClipper_Begin(clipper, #self.transcript + 1)
+
+      while ImGui.ListClipper_Step(clipper) do
+        local display_start, display_end = ImGui.ListClipper_GetDisplayRange(clipper)
+
+        for row = display_start, display_end - 1 do
+          if row == 0 then
+            ImGui.TableHeadersRow(ctx)
+            self:sort_table()
+          else
+            local segment = self.transcript:get_segment(row)
+            ImGui.TableNextRow(ctx)
+            ImGui.TableNextColumn(ctx)
+            self:render_segment_actions(segment, row)
+            for _, column in pairs(columns) do
+              ImGui.TableNextColumn(ctx)
+              self:render_table_cell(segment, column)
+            end
+          end
         end
       end
     end)


### PR DESCRIPTION
Testing a 49152-segment transcript, the before/after fps was 0.9 -> 33.3.

The import takes a few long-feeling seconds but once loaded everything remains snappy.

Resolves #113.