### PR TITLE
Focus popup windows instead of using always-on-top

### DIFF
--- a/reascripts/ReaSpeech/libs/ToolWindow.lua
+++ b/reascripts/ReaSpeech/libs/ToolWindow.lua
@@ -192,8 +192,11 @@ function ToolWindow.default_guard(o)
 end
 
 function ToolWindow.present(o)
-  o._tool_window.presenting = true
-  o._tool_window.focusing = true
+  if o._tool_window.presenting then
+    o._tool_window.focusing = true
+  else
+    o._tool_window.presenting = true
+  end
 end
 
 function ToolWindow.focus(o)
@@ -218,6 +221,13 @@ function ToolWindow.render(o)
   local opening = not o:is_open()
   if opening then
     o:open()
+  elseif state.focusing then
+    -- ImGui.SetNextWindowFocus doesn't seem to bring windows to the top.
+    -- Instead, close and schedule reopening of the window.
+    o:close()
+    state.presenting = true
+    state.focusing = false
+    return
   end
 
   local f = function()
@@ -235,12 +245,6 @@ end
 
 function ToolWindow._render_window(o)
   local state = o._tool_window
-
-  if state.focusing then
-    app:debug('trying to focus')
-    ImGui.SetNextWindowFocus(o.ctx)
-    state.focusing = false
-  end
 
   if state.position == ToolWindow.POSITION_CENTER then
     local center = {ImGui.Viewport_GetCenter(ImGui.GetWindowViewport(o.ctx))}

--- a/reascripts/ReaSpeech/libs/ToolWindow.lua
+++ b/reascripts/ReaSpeech/libs/ToolWindow.lua
@@ -140,6 +140,7 @@ ToolWindow.init = function(o, config)
 
   ToolWindow._wrap_method_0_args(o, 'close', function()
     state.presenting = false
+    state.focusing = false
     state.is_open = false
   end)
 
@@ -147,6 +148,7 @@ ToolWindow.init = function(o, config)
 
   o.present = ToolWindow.present
   o.presenting = ToolWindow.presenting
+  o.focusing = ToolWindow.focusing
 
   o.render = ToolWindow.render
 
@@ -165,6 +167,7 @@ function ToolWindow._make_config(o, config)
     is_open = false,
     position = config.position or ToolWindow.POSITION_CENTER,
     presenting = false,
+    focusing = false,
     theme = config.theme or ToolWindow.DEFAULT_THEME(),
     title = config.title or ToolWindow.DEFAULT_TITLE,
     width = config.width or ToolWindow.DEFAULT_WIDTH,
@@ -190,6 +193,11 @@ end
 
 function ToolWindow.present(o)
   o._tool_window.presenting = true
+  o._tool_window.focusing = true
+end
+
+function ToolWindow.focus(o)
+  o._tool_window.focusing = true
 end
 
 function ToolWindow.presenting(o)
@@ -227,6 +235,12 @@ end
 
 function ToolWindow._render_window(o)
   local state = o._tool_window
+
+  if state.focusing then
+    app:debug('trying to focus')
+    ImGui.SetNextWindowFocus(o.ctx)
+    state.focusing = false
+  end
 
   if state.position == ToolWindow.POSITION_CENTER then
     local center = {ImGui.Viewport_GetCenter(ImGui.GetWindowViewport(o.ctx))}

--- a/reascripts/ReaSpeech/source/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ASRActions.lua
@@ -105,7 +105,7 @@ function ASRActions:import_button()
 
   self._import_button = ReaSpeechButton.new({
     label = "Import Transcript",
-    on_click = function () app.importer:open() end
+    on_click = function () app.importer:present() end
   })
 
   return self._import_button

--- a/reascripts/ReaSpeech/source/TranscriptAnnotationsUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptAnnotationsUI.lua
@@ -25,7 +25,6 @@ function TranscriptAnnotationsUI:init()
       | ImGui.WindowFlags_AlwaysAutoResize()
       | ImGui.WindowFlags_NoCollapse()
       | ImGui.WindowFlags_NoDocking()
-      | ImGui.WindowFlags_TopMost(),
   })
 
   self.disabler = ReaUtil.disabler(ctx)

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -26,7 +26,6 @@ function TranscriptExporter:init()
       | ImGui.WindowFlags_AlwaysAutoResize()
       | ImGui.WindowFlags_NoCollapse()
       | ImGui.WindowFlags_NoDocking()
-      | ImGui.WindowFlags_TopMost(),
   })
 
   self.export_formats = TranscriptExporterFormats.new {

--- a/reascripts/ReaSpeech/source/TranscriptImporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptImporter.lua
@@ -22,7 +22,6 @@ function TranscriptImporter:init()
       | ImGui.WindowFlags_AlwaysAutoResize()
       | ImGui.WindowFlags_NoCollapse()
       | ImGui.WindowFlags_NoDocking()
-      | ImGui.WindowFlags_TopMost(),
   })
 
   self.file_selector = ReaSpeechFileSelector.new({

--- a/reascripts/ReaSpeech/tests/TestToolWindow.lua
+++ b/reascripts/ReaSpeech/tests/TestToolWindow.lua
@@ -198,6 +198,7 @@ function TestToolWindow:testRender()
   ImGui.Cond_FirstUseEver = function() return 2 end
   ImGui.End = function(_) end
   ImGui.GetWindowViewport = function() end
+  ImGui.SetNextWindowFocus = function(_) end
   ImGui.SetNextWindowPos = function(_, _, _, _, _, _) end
   ImGui.SetNextWindowSize = function(_, _, _, _) end
   ImGui.Viewport_GetCenter = function() return 0, 0 end

--- a/scripts/reawatch
+++ b/scripts/reawatch
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker exec -w /app/reascripts/$1 reaspeech-reaspeech-1 sh -c "fswatch -m poll_monitor source/*.lua tests/*.lua | xargs -I{} make"
+docker exec -w /app/reascripts/$1 reaspeech-reaspeech-1 sh -c "fswatch -m poll_monitor source/*.lua libs/*.lua tests/*.lua | xargs -I{} make"

--- a/scripts/reawatch-gpu
+++ b/scripts/reawatch-gpu
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker exec -w /app/reascripts/$1 reaspeech-reaspeech-gpu-1 sh -c "fswatch -m poll_monitor source/*.lua tests/*.lua | xargs -I{} make"
+docker exec -w /app/reascripts/$1 reaspeech-reaspeech-gpu-1 sh -c "fswatch -m poll_monitor source/*.lua libs/*.lua tests/*.lua | xargs -I{} make"

--- a/scripts/reawatch-gpu.bat
+++ b/scripts/reawatch-gpu.bat
@@ -1,1 +1,1 @@
-docker exec -w /app/reascripts/%1 reaspeech-reaspeech-gpu-1 sh -c "fswatch -m poll_monitor source/*.lua tests/*.lua | xargs -I{} make"
+docker exec -w /app/reascripts/%1 reaspeech-reaspeech-gpu-1 sh -c "fswatch -m poll_monitor source/*.lua libs/*.lua tests/*.lua | xargs -I{} make"

--- a/scripts/reawatch.bat
+++ b/scripts/reawatch.bat
@@ -1,1 +1,1 @@
-docker exec -w /app/reascripts/%1 reaspeech-reaspeech-1 sh -c "fswatch -m poll_monitor source/*.lua tests/*.lua | xargs -I{} make"
+docker exec -w /app/reascripts/%1 reaspeech-reaspeech-1 sh -c "fswatch -m poll_monitor source/*.lua libs/*.lua tests/*.lua | xargs -I{} make"


### PR DESCRIPTION
Fixes #120

The always-on-top feature of ImGui seems problematic on Linux, as it steals focus from other applications and renders them unusable. Instead, we should just focus the popup window if it is not focused already. This would solve the same problem I had intended to solve with always-on-top: when a window is already open, but buried by the main window, it's very difficult to discover what happened to it, and the button just seems broken.

I was unable to get `SetNextWindowFocus` to bring the popup window to the top. It does appear to set focus, but it remains buried. So, I instead opted for closing the window and using the `presenting` flag to cause it to be reopened on the next render.