### PR TITLE
Rebuild ImGui Context when invalid

### DIFF
--- a/reascripts/ReaSpeech/Makefile
+++ b/reascripts/ReaSpeech/Makefile
@@ -4,7 +4,7 @@ LUA54=lua5.4
 LUAC54=luac5.4
 LUACHECK=luacheck
 
-LIBS=EnvUtil.lua ExecProcess.lua ImGuiTheme.lua PathUtil.lua Polo.lua ReaIter.lua ReaUtil.lua Storage.lua TableUtils.lua Tempfile.lua Trap.lua
+LIBS=Ctx.lua EnvUtil.lua ExecProcess.lua ImGuiTheme.lua PathUtil.lua Polo.lua ReaIter.lua ReaUtil.lua Storage.lua TableUtils.lua Tempfile.lua Trap.lua
 VENDOR=json.lua url.lua
 
 source:=$(wildcard libs/*.lua source/*.lua source/include/*.lua)

--- a/reascripts/ReaSpeech/libs/ToolWindow.lua
+++ b/reascripts/ReaSpeech/libs/ToolWindow.lua
@@ -11,8 +11,6 @@
       arguments:
         target_object (table) - the object to extend
         config_table (table) - configuration options
-          ctx (userdata) - the ImGui context to use
-            default: global ctx object
           guard (function) - a function to determine if the window should render
             default: function returning true if (presenting or is_open)
           title (string) - the window title
@@ -101,11 +99,11 @@ ToolWindow.modal = function(o, config)
   config.is_modal = true
 
   ToolWindow._wrap_method_0_args(o, 'open', function()
-    ImGui.OpenPopup(o.ctx, o._tool_window.title)
+    ImGui.OpenPopup(ctx, o._tool_window.title)
   end)
 
   ToolWindow._wrap_method_0_args(o, 'close', function()
-    ImGui.CloseCurrentPopup(o.ctx)
+    ImGui.CloseCurrentPopup(ctx)
   end)
 
    ToolWindow.init(o, config)
@@ -113,8 +111,6 @@ end
 
 ToolWindow.init = function(o, config)
   config = config or {}
-
-  o.ctx = config.ctx or ctx
 
   local state = ToolWindow._make_config(o, config)
 
@@ -231,7 +227,7 @@ function ToolWindow.render(o)
   end
 
   local f = function()
-    state.theme:wrap(o.ctx, function()
+    state.theme:wrap(ctx, function()
       ToolWindow._render_window(o)
     end, Trap)
   end
@@ -247,22 +243,22 @@ function ToolWindow._render_window(o)
   local state = o._tool_window
 
   if state.position == ToolWindow.POSITION_CENTER then
-    local center = {ImGui.Viewport_GetCenter(ImGui.GetWindowViewport(o.ctx))}
-    ImGui.SetNextWindowPos(o.ctx, center[1], center[2], ImGui.Cond_Appearing(), 0.5, 0.5)
+    local center = {ImGui.Viewport_GetCenter(ImGui.GetWindowViewport(ctx))}
+    ImGui.SetNextWindowPos(ctx, center[1], center[2], ImGui.Cond_Appearing(), 0.5, 0.5)
   elseif type(state.position) == 'table' and #state.position == 2 then
     local position = state.position
-    ImGui.SetNextWindowPos(o.ctx, position[1], position[2], ImGui.Cond_Appearing())
+    ImGui.SetNextWindowPos(ctx, position[1], position[2], ImGui.Cond_Appearing())
   end
 
-  ImGui.SetNextWindowSize(o.ctx, state.width, state.height, ImGui.Cond_FirstUseEver())
-  local visible, open = state.begin_f(o.ctx, state.title, true, state.window_flags)
+  ImGui.SetNextWindowSize(ctx, state.width, state.height, ImGui.Cond_FirstUseEver())
+  local visible, open = state.begin_f(ctx, state.title, true, state.window_flags)
   if visible then
     Trap(function ()
       if o.render_content then
         o:render_content()
       end
     end)
-    state.end_f(o.ctx)
+    state.end_f(ctx)
   else
     -- Checking for "not NoCollapse" here accounts for the main window
     -- that can be minimized and expanded.
@@ -279,8 +275,8 @@ function ToolWindow._render_window(o)
   end
 end
 
-function ToolWindow.render_separator(o)
-  ImGui.Dummy(o.ctx, 0, 0)
-  ImGui.Separator(o.ctx)
-  ImGui.Dummy(o.ctx, 0, 0)
+function ToolWindow.render_separator(_o)
+  ImGui.Dummy(ctx, 0, 0)
+  ImGui.Separator(ctx)
+  ImGui.Dummy(ctx, 0, 0)
 end

--- a/reascripts/ReaSpeech/source/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ASRActions.lua
@@ -19,8 +19,6 @@ function ASRActions:init()
   assert(self.plugin, 'ASRActions: plugin is required')
 
   Logging.init(self, 'ASRActions')
-
-  self.disabler = ReaUtil.disabler(ctx)
 end
 
 function ASRActions:selected_tracks_button()

--- a/reascripts/ReaSpeech/source/Fonts.lua
+++ b/reascripts/ReaSpeech/source/Fonts.lua
@@ -8,7 +8,7 @@ Fonts = {
   SIZE = 15,
 }
 
-function Fonts:init()
+function Fonts:init(ctx)
   self.main = ImGui.CreateFont('sans-serif', self.SIZE)
   ImGui.Attach(ctx, self.main)
 

--- a/reascripts/ReaSpeech/source/KeyMap.lua
+++ b/reascripts/ReaSpeech/source/KeyMap.lua
@@ -18,13 +18,12 @@ KeyMap = Polo {
 }
 
 function KeyMap:init()
-  self.ctx = self.ctx or ctx
   self.bindings = self.bindings or {}
 end
 
 function KeyMap:react()
   for key, binding in pairs(self.bindings) do
-    if ImGui.IsKeyPressed(self.ctx, key) then
+    if ImGui.IsKeyPressed(ctx, key) then
       if type(binding) == 'function' then
         binding()
       elseif type(binding) == 'table' then

--- a/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechActionsUI.lua
@@ -7,11 +7,10 @@ ReaSpeechActionsUI.lua - Main action bar UI in ReaSpeech
 ReaSpeechActionsUI = Polo {}
 
 function ReaSpeechActionsUI:init()
-  self.disabler = ReaUtil.disabler(ctx)
 end
 
 function ReaSpeechActionsUI:render()
-  local disable_if = self.disabler
+  local disable_if = ReaUtil.disabler(ctx)
   local progress
   Trap(function ()
     progress = self.worker:progress()

--- a/reascripts/ReaSpeech/source/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechMain.lua
@@ -13,8 +13,7 @@ function ReaSpeechMain:main()
   if not self:check_imgui() then return end
   reaper.atexit(function () self:onexit() end)
 
-  ctx = ImGui.CreateContext(ReaSpeechUI.TITLE, ReaSpeechUI.config_flags())
-  Fonts:init()
+  self:build_ctx()
   Theme:init()
   app = ReaSpeechUI.new()
   app:present()
@@ -24,9 +23,17 @@ end
 function ReaSpeechMain:loop()
   return function()
     if app:presenting() or app:is_open() then
+      self:build_ctx()
       Trap(function() app:react() end)
       reaper.defer(self:loop())
     end
+  end
+end
+
+function ReaSpeechMain:build_ctx()
+  if not ImGui.ValidatePtr(ctx, 'ImGui_Context*') then
+    ctx = ImGui.CreateContext(ReaSpeechUI.TITLE, ReaSpeechUI.config_flags())
+    Fonts:init(ctx)
   end
 end
 

--- a/reascripts/ReaSpeech/source/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechMain.lua
@@ -11,29 +11,25 @@ ReaSpeechMain = {}
 
 function ReaSpeechMain:main()
   if not self:check_imgui() then return end
-  reaper.atexit(function () self:onexit() end)
+  reaper.atexit(function () self:on_exit() end)
 
-  self:build_ctx()
+  self:init_ctx()
+  ctx = Ctx()
+
   Theme:init()
   app = ReaSpeechUI.new()
   app:present()
+
   reaper.defer(self:loop())
 end
 
 function ReaSpeechMain:loop()
   return function()
     if app:presenting() or app:is_open() then
-      self:build_ctx()
+      ctx = Ctx()
       Trap(function() app:react() end)
       reaper.defer(self:loop())
     end
-  end
-end
-
-function ReaSpeechMain:build_ctx()
-  if not ImGui.ValidatePtr(ctx, 'ImGui_Context*') then
-    ctx = ImGui.CreateContext(ReaSpeechUI.TITLE, ReaSpeechUI.config_flags())
-    Fonts:init(ctx)
   end
 end
 
@@ -51,6 +47,14 @@ function ReaSpeechMain:check_imgui()
   end
 end
 
-function ReaSpeechMain:onexit()
+function ReaSpeechMain:init_ctx()
+  Ctx.label = ReaSpeechUI.TITLE
+  Ctx.flags = ReaSpeechUI.config_flags()
+  Ctx.on_create = function (ctx)
+    Fonts:init(ctx)
+  end
+end
+
+function ReaSpeechMain:on_exit()
   Tempfile:remove_all()
 end

--- a/reascripts/ReaSpeech/source/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechUI.lua
@@ -18,7 +18,6 @@ ReaSpeechUI = Polo {
 
 function ReaSpeechUI:init()
   ToolWindow.init(self, {
-    ctx = ctx,
     title = self.TITLE,
     width = self.WIDTH,
     height = self.HEIGHT,

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -14,18 +14,17 @@ function ReaSpeechWidget:init()
     self.state = Storage.memory(self.default)
   end
   assert(self.renderer, "renderer not provided")
-  self.ctx = self.ctx or ctx
   self.widget_id = self.widget_id or reaper.genGuid()
   self.on_set = nil
 end
 
 function ReaSpeechWidget:render(...)
-  ImGui.PushID(self.ctx, self.widget_id)
+  ImGui.PushID(ctx, self.widget_id)
   local args = ...
   Trap(function()
     self.renderer(self, args)
   end)
-  ImGui.PopID(self.ctx)
+  ImGui.PopID(ctx)
 end
 
 function ReaSpeechWidget:render_help_icon()
@@ -38,14 +37,14 @@ function ReaSpeechWidget:render_label(label)
   local options = self.options
   label = label or options.label
 
-  ImGui.Text(self.ctx, label)
+  ImGui.Text(ctx, label)
 
   if label ~= '' and options.help_text then
-    ImGui.SameLine(self.ctx)
+    ImGui.SameLine(ctx)
     self:render_help_icon()
   end
 
-  ImGui.Dummy(self.ctx, 0, 0)
+  ImGui.Dummy(ctx, 0, 0)
 end
 
 function ReaSpeechWidget:value()
@@ -101,11 +100,11 @@ ReaSpeechCheckbox.renderer = function (self, column)
     label = options.label_short
   end
 
-  local rv, value = ImGui.Checkbox(self.ctx, label, self:value())
+  local rv, value = ImGui.Checkbox(ctx, label, self:value())
 
   if options.help_text then
-    ImGui.SameLine(self.ctx)
-    ImGui.SetCursorPosY(self.ctx, ImGui.GetCursorPosY(self.ctx) + 7)
+    ImGui.SameLine(ctx)
+    ImGui.SetCursorPosY(ctx, ImGui.GetCursorPosY(ctx) + 7)
     self:render_help_icon()
   end
 
@@ -147,7 +146,7 @@ ReaSpeechTextInput.renderer = function (self)
 
   local imgui_label = ("##%s"):format(options.label)
 
-  local rv, value = ImGui.InputText(self.ctx, imgui_label, self:value())
+  local rv, value = ImGui.InputText(ctx, imgui_label, self:value())
 
   if rv then
     self:set(value)
@@ -188,16 +187,16 @@ ReaSpeechCombo.renderer = function (self)
   local item_label = options.item_labels[self:value()] or ""
   local combo_flags = ImGui.ComboFlags_HeightLarge()
 
-  if ImGui.BeginCombo(self.ctx, imgui_label, item_label, combo_flags) then
+  if ImGui.BeginCombo(ctx, imgui_label, item_label, combo_flags) then
     Trap(function()
       for _, item in pairs(options.items) do
         local is_selected = (item == self:value())
-        if ImGui.Selectable(self.ctx, options.item_labels[item], is_selected) then
+        if ImGui.Selectable(ctx, options.item_labels[item], is_selected) then
           self:set(item)
         end
       end
     end)
-    ImGui.EndCombo(self.ctx)
+    ImGui.EndCombo(ctx)
   end
 end
 
@@ -222,16 +221,16 @@ ReaSpeechTabBar.new = function (options)
 end
 
 ReaSpeechTabBar.renderer = function (self)
-  if ImGui.BeginTabBar(self.ctx, 'TabBar') then
+  if ImGui.BeginTabBar(ctx, 'TabBar') then
     for _, tab in pairs(self.options.tabs) do
-      if ImGui.BeginTabItem(self.ctx, tab.label) then
+      if ImGui.BeginTabItem(ctx, tab.label) then
         Trap(function()
           self:set(tab.key)
         end)
-        ImGui.EndTabItem(self.ctx)
+        ImGui.EndTabItem(ctx)
       end
     end
-    ImGui.EndTabBar(self.ctx)
+    ImGui.EndTabBar(ctx)
   end
 end
 
@@ -267,10 +266,10 @@ ReaSpeechButtonBar.new = function (options)
   local with_button_color = function (selected, f)
     local color = Theme.COLORS.dark_gray_translucent
     if selected then color = Theme.COLORS.medium_gray_opaque end
-    ImGui.PushStyleColor(o.ctx, ImGui.Col_Button(), color)
-    ImGui.PushStyleColor(o.ctx, ImGui.Col_ButtonHovered(), color)
+    ImGui.PushStyleColor(ctx, ImGui.Col_Button(), color)
+    ImGui.PushStyleColor(ctx, ImGui.Col_ButtonHovered(), color)
     Trap(f)
-    ImGui.PopStyleColor(o.ctx, 2)
+    ImGui.PopStyleColor(ctx, 2)
   end
 
   o.layout = ColumnLayout.new {
@@ -287,7 +286,7 @@ ReaSpeechButtonBar.new = function (options)
 
       local button_label, model_name = table.unpack(options.buttons[column.num])
       with_button_color(o:value() == model_name, function ()
-        if ImGui.Button(o.ctx, button_label, column.width) then
+        if ImGui.Button(ctx, button_label, column.width) then
           o:set(model_name)
         end
       end)
@@ -323,11 +322,11 @@ ReaSpeechButton.new = function(options)
 end
 
 ReaSpeechButton.renderer = function(self)
-  local disable_if = ReaUtil.disabler(self.ctx)
+  local disable_if = ReaUtil.disabler(ctx)
   local options = self.options
 
   disable_if(options.disabled, function()
-    if ImGui.Button(self.ctx, options.label, options.width) then
+    if ImGui.Button(ctx, options.label, options.width) then
       Trap(options.on_click)
     end
   end)
@@ -387,22 +386,22 @@ end
 ReaSpeechFileSelector.renderer = function(self)
   local options = self.options
 
-  ImGui.Text(self.ctx, options.label)
+  ImGui.Text(ctx, options.label)
 
   ReaSpeechFileSelector.render_jsapi_notice(self)
 
   options.button:render()
-  ImGui.SameLine(self.ctx)
+  ImGui.SameLine(ctx)
 
   local w, _
   if not options.input_width then
-    w, _ = ImGui.GetContentRegionAvail(self.ctx)
+    w, _ = ImGui.GetContentRegionAvail(ctx)
   else
     w = options.input_width
   end
 
-  ImGui.SetNextItemWidth(self.ctx, w)
-  local file_changed, file = ImGui.InputText(self.ctx, '##file', self:value())
+  ImGui.SetNextItemWidth(ctx, w)
+  local file_changed, file = ImGui.InputText(ctx, '##file', self:value())
   if file_changed then
     self:set(file)
   end
@@ -413,14 +412,14 @@ ReaSpeechFileSelector.render_jsapi_notice = function(self)
     return
   end
 
-  local _, spacing_v = ImGui.GetStyleVar(self.ctx, ImGui.StyleVar_ItemSpacing())
-  ImGui.PushStyleVar(self.ctx, ImGui.StyleVar_ItemSpacing(), 0, spacing_v)
-  ImGui.Text(self.ctx, "To enable file selector, ")
-  ImGui.SameLine(self.ctx)
+  local _, spacing_v = ImGui.GetStyleVar(ctx, ImGui.StyleVar_ItemSpacing())
+  ImGui.PushStyleVar(ctx, ImGui.StyleVar_ItemSpacing(), 0, spacing_v)
+  ImGui.Text(ctx, "To enable file selector, ")
+  ImGui.SameLine(ctx)
   Widgets.link('install js_ReaScriptAPI', ReaUtil.url_opener(ReaSpeechFileSelector.JSREASCRIPT_URL))
-  ImGui.SameLine(self.ctx)
-  ImGui.Text(self.ctx, ".")
-  ImGui.PopStyleVar(self.ctx)
+  ImGui.SameLine(ctx)
+  ImGui.Text(ctx, ".")
+  ImGui.PopStyleVar(ctx)
 end
 
 ReaSpeechListBox = {}
@@ -457,7 +456,7 @@ ReaSpeechListBox.renderer = function(self)
   local imgui_label = ("##%s"):format(options.label)
 
   local needs_update = false
-  if ImGui.BeginListBox(self.ctx, imgui_label) then
+  if ImGui.BeginListBox(ctx, imgui_label) then
     Trap(function()
       local current = self:value()
       local new_value = {}
@@ -465,22 +464,22 @@ ReaSpeechListBox.renderer = function(self)
         new_value[item] = current[item] or false
         local is_selected = current[item]
         local label = options.item_labels[item]
-        ImGui.PushID(self.ctx, 'item' .. i)
+        ImGui.PushID(ctx, 'item' .. i)
         Trap(function()
-          local result, now_selected = ImGui.Selectable(self.ctx, label, is_selected)
+          local result, now_selected = ImGui.Selectable(ctx, label, is_selected)
 
           if result and is_selected ~= now_selected then
             needs_update = true
             new_value[item] = now_selected
           end
         end)
-        ImGui.PopID(self.ctx)
+        ImGui.PopID(ctx)
       end
 
       if needs_update then
         self:set(new_value)
       end
     end)
-    ImGui.EndListBox(self.ctx)
+    ImGui.EndListBox(ctx)
   end
 end

--- a/reascripts/ReaSpeech/source/TranscriptAnnotationsUI.lua
+++ b/reascripts/ReaSpeech/source/TranscriptAnnotationsUI.lua
@@ -28,8 +28,6 @@ function TranscriptAnnotationsUI:init()
       | ImGui.WindowFlags_NoDocking()
   })
 
-  self.disabler = ReaUtil.disabler(ctx)
-
   self.annotation_types = TranscriptAnnotationTypes.new {
     TranscriptAnnotationTypes.project_markers(),
     TranscriptAnnotationTypes.project_regions(),
@@ -59,7 +57,7 @@ function TranscriptAnnotationsUI:render_content()
 end
 
 function TranscriptAnnotationsUI:render_buttons(is_disabled)
-  local disable_if = self.disabler
+  local disable_if = ReaUtil.disabler(ctx)
 
   disable_if(is_disabled, function()
     if ImGui.Button(ctx, 'Create', self.BUTTON_WIDTH, 0) then

--- a/reascripts/common/libs/Ctx.lua
+++ b/reascripts/common/libs/Ctx.lua
@@ -1,0 +1,33 @@
+--[[
+
+  Ctx.lua - ImGui context builder that ensures a valid context
+
+  Usage:
+
+    Ctx.label = 'My Application'
+    Ctx.flags = ImGui.ConfigFlags_DockingEnable()
+    Ctx.on_create = function (ctx)
+      -- Attach fonts, etc.
+    end
+
+    ImGui.Text(Ctx(), 'Hello, world!')
+
+]]--
+
+Ctx = {
+  label = 'Application',
+  flags = 0,
+  ctx = nil,
+
+  on_create = function (_ctx) end,
+
+  __call = function (self)
+    if not ImGui.ValidatePtr(self.ctx, 'ImGui_Context*') then
+      self.ctx = ImGui.CreateContext(self.label, self.flags)
+      self.on_create(self.ctx)
+    end
+    return self.ctx
+  end
+}
+
+setmetatable(Ctx, Ctx)


### PR DESCRIPTION
I'm still seeing intermittent issues with invalid contexts on OSX (bug #122). It typically happens before the first deferred call to `ReaSpeechMain:loop()`. I tried making this initial call immediate instead of deferred, but it made the problem worse.

As a workaround, I think we have to assume that the context could be invalidated at any point, and ensure that it gets recreated before each iteration of the render loop. This means that we can't store the context as an instance variable, since it can be replaced, and we don't want to hold onto the old context. We could store a factory instead, if we wanted to reduce dependency on the `ctx` global; for the sake of simplicity, I have opted to return to using the global here.