### PR TITLE
UX improvements for TranscriptExporter filename

### DIFF
--- a/reascripts/ReaSpeech/source/AlertPopup.lua
+++ b/reascripts/ReaSpeech/source/AlertPopup.lua
@@ -35,9 +35,9 @@ function AlertPopup:render_content()
   if type(self.msg) == 'function' then
     self.msg()
     return
-  else
-    ImGui.Text(ctx, self.msg)
   end
+  ImGui.Text(ctx, self.msg)
+
   self:render_separator()
   if ImGui.Button(ctx, 'OK', self.BUTTON_WIDTH, 0) then
     self:close()

--- a/reascripts/ReaSpeech/source/AlertPopup.lua
+++ b/reascripts/ReaSpeech/source/AlertPopup.lua
@@ -32,7 +32,12 @@ function AlertPopup:show(title, msg)
 end
 
 function AlertPopup:render_content()
-  ImGui.Text(ctx, self.msg)
+  if type(self.msg) == 'function' then
+    self.msg()
+    return
+  else
+    ImGui.Text(ctx, self.msg)
+  end
   self:render_separator()
   if ImGui.Button(ctx, 'OK', self.BUTTON_WIDTH, 0) then
     self:close()

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -15,7 +15,7 @@ function ReaSpeechWidget:init()
   end
   assert(self.renderer, "renderer not provided")
   self.widget_id = self.widget_id or reaper.genGuid()
-  self.on_set = nil
+  self.on_set = self.options and self.options.on_set or function() end
 end
 
 function ReaSpeechWidget:render(...)

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -67,6 +67,8 @@ ReaSpeechCheckbox.new = function (options)
   }
   options.default = options.default or false
 
+  options.disabled_if = options.disabled_if or function() return false end
+
   options.changed_handler = options.changed_handler or function(_) end
 
   local o = ReaSpeechWidget.new({
@@ -93,6 +95,7 @@ ReaSpeechCheckbox.simple = function(default_value, label, changed_handler)
 end
 
 ReaSpeechCheckbox.renderer = function (self, column)
+  local disable_if = ReaUtil.disabler(ctx)
   local options = self.options
   local label = options.label_long
 
@@ -100,18 +103,20 @@ ReaSpeechCheckbox.renderer = function (self, column)
     label = options.label_short
   end
 
-  local rv, value = ImGui.Checkbox(ctx, label, self:value())
+  disable_if(self.options.disabled_if(), function()
+    local rv, value = ImGui.Checkbox(ctx, label, self:value())
 
-  if options.help_text then
-    ImGui.SameLine(ctx)
-    ImGui.SetCursorPosY(ctx, ImGui.GetCursorPosY(ctx) + 7)
-    self:render_help_icon()
-  end
+    if options.help_text then
+      ImGui.SameLine(ctx)
+      ImGui.SetCursorPosY(ctx, ImGui.GetCursorPosY(ctx) + 7)
+      self:render_help_icon()
+    end
 
-  if rv then
-    self:set(value)
-    options.changed_handler(value)
-  end
+    if rv then
+      self:set(value)
+      options.changed_handler(value)
+    end
+  end)
 end
 
 ReaSpeechTextInput = {}

--- a/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ReaSpeechWidgets.lua
@@ -406,7 +406,8 @@ ReaSpeechFileSelector.renderer = function(self)
   end
 
   ImGui.SetNextItemWidth(ctx, w)
-  local file_changed, file = ImGui.InputText(ctx, '##file', self:value())
+  local hint = '...or type one here.'
+  local file_changed, file = ImGui.InputTextWithHint(ctx, '##file', hint, self:value())
   if file_changed then
     self:set(file)
   end

--- a/reascripts/ReaSpeech/source/Theme.lua
+++ b/reascripts/ReaSpeech/source/Theme.lua
@@ -15,6 +15,7 @@ Theme = {
     medium_gray_opaque = 0x5C5C5CFF,
     pink_opaque = 0xE24097FF,
     very_dark_gray_semi_opaque = 0x1A1A1AFB,
+    bold_red = 0xff0000ff,
   }
 }
 

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -119,10 +119,7 @@ function TranscriptExporter:update_target_filename_ui()
   if is_full_path then
     self.target_filename_display:set(full_path)
   else
-    local display = table.concat({
-      '<Project Resources>',
-      full_path:sub(#reaper.GetProjectPath() + 2)
-    }, PathUtil._path_separator())
+    local display = PathUtil.join('<Project Resources>', full_path:sub(#reaper.GetProjectPath() + 2))
     self.target_filename_display:set(display)
   end
 

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -105,7 +105,19 @@ function TranscriptExporter:show_success()
     self.alert_popup.onclose = nil
     self:close()
   end
-  self.alert_popup:show('Export Successful', 'Exported ' .. self.export_formats:selected_key() .. ' to: ' .. self.target_filename:get())
+
+  self.alert_popup:show('Export Successful', function()
+    local file_path = self.target_filename:get()
+    local filename = PathUtil.get_filename(self.target_filename:get())
+
+    ImGui.Text(ctx, 'Exported ' .. self.export_formats:selected_key() .. ' to: ')
+    ImGui.SameLine(ctx)
+
+    Widgets.link(filename, function()
+      ExecProcess.via_tempfile(PathUtil.get_reveal_command(file_path)):no_wait()
+      self.alert_popup:close()
+    end)
+  end)
 end
 
 function TranscriptExporter:show_error(msg)

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -29,29 +29,24 @@ function TranscriptExporter:init()
       | ImGui.WindowFlags_NoDocking()
   })
 
-  local export_formats = TranscriptExporterFormats.new {
+  self.export_formats = TranscriptExporterFormats.new {
     TranscriptExportFormat.exporter_json(),
     TranscriptExportFormat.exporter_srt(),
     TranscriptExportFormat.exporter_csv(),
   }
-  function export_formats.on_change()
+  function self.export_formats.on_change()
     self:update_target_filename_ui()
   end
 
-  self.export_formats = export_formats
   self.export_options = {}
-
-  local _self = self
 
   self.file_selector = ReaSpeechFileSelector.new({
     label = 'File',
     save = true,
     button_width = self.BUTTON_WIDTH,
-    input_width = self.FILE_WIDTH
+    input_width = self.FILE_WIDTH,
+    on_set = function() self:update_target_filename_ui() end,
   })
-  function self.file_selector:on_set()
-    _self:update_target_filename_ui()
-  end
 
   -- invisible state to manage the UX around the target filename
   self.is_full_path = Storage.memory(false)
@@ -70,7 +65,7 @@ function TranscriptExporter:init()
     disabled_if = function() return has_extension() end,
   }
   self.apply_extension.options.changed_handler = function()
-    _self:update_target_filename_ui()
+    self:update_target_filename_ui()
   end
 
   self.alert_popup = AlertPopup.new {}

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -140,7 +140,7 @@ function TranscriptExporter:show_success()
     ImGui.SameLine(ctx)
 
     Widgets.link(filename, function()
-      ExecProcess.via_tempfile(PathUtil.get_reveal_command(file_path)):no_wait()
+      ExecProcess.new(PathUtil.get_reveal_command(file_path)):no_wait()
       self.alert_popup:close()
     end)
   end)

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -52,7 +52,6 @@ function TranscriptExporter:init()
   self.is_full_path = Storage.memory(false)
   self.target_filename_exists = Storage.memory(false)
   self.has_extension = Storage.memory(false)
-  local has_extension = function() return self.has_extension:get() end
 
   -- this is the value that will actually be used after the
   -- file_selector contents are processed (relative vs full path,
@@ -62,11 +61,12 @@ function TranscriptExporter:init()
   self.apply_extension = ReaSpeechCheckbox.new {
     default = true,
     label_long = 'Apply Extension',
-    disabled_if = function() return has_extension() end,
+    disabled_if = function() return self.has_extension:get() end,
+    changed_handler = function()
+      if not self.apply_extension then return end
+      self:update_target_filename_ui()
+    end
   }
-  self.apply_extension.options.changed_handler = function()
-    self:update_target_filename_ui()
-  end
 
   self.alert_popup = AlertPopup.new {}
 end
@@ -86,11 +86,10 @@ function TranscriptExporter:update_target_filename_ui()
   -- automatically apply default extension for format, if desired
   if self.apply_extension:value() then
     local extension = self.export_formats:selected_format().extension
-    local with_extension = PathUtil.apply_extension(full_path, extension)
-    self.target_filename:set(with_extension)
-  else
-    self.target_filename:set(full_path)
+    full_path = PathUtil.apply_extension(full_path, extension)
   end
+
+  self.target_filename:set(full_path)
 
   self.target_filename_exists:set(reaper.file_exists(self.target_filename:get()))
 end

--- a/reascripts/ReaSpeech/source/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/TranscriptExporter.lua
@@ -71,8 +71,32 @@ function TranscriptExporter:init()
   self.alert_popup = AlertPopup.new {}
 end
 
+function TranscriptExporter:open()
+  self:reset_form()
+end
+
+function TranscriptExporter:reset_form()
+  self.file_selector:set('')
+  self.apply_extension:set(true)
+  self:update_target_filename_ui()
+end
+
+function TranscriptExporter:clear_target_filename()
+  self.target_filename:set('')
+  self.target_filename_exists:set(false)
+  self.has_extension:set(false)
+  self.is_full_path:set(false)
+end
+
 function TranscriptExporter:update_target_filename_ui()
-  local full_path = PathUtil.get_real_path(self.file_selector:value())
+  local specified_path = self.file_selector:value()
+
+  if specified_path == '' then
+    self:clear_target_filename()
+    return
+  end
+
+  local full_path = PathUtil.get_real_path(specified_path)
 
   self.has_extension:set(PathUtil.has_extension(full_path))
   self.is_full_path:set(PathUtil.is_full_path(full_path))

--- a/reascripts/ReaSpeech/source/Widgets.lua
+++ b/reascripts/ReaSpeech/source/Widgets.lua
@@ -86,3 +86,8 @@ function Widgets.tooltip(text)
 
   ImGui.EndTooltip(ctx)
 end
+
+function Widgets.warning(text)
+  local bold_red = 0xff0000ff
+  ImGui.TextColored(ctx, bold_red, text)
+end

--- a/reascripts/ReaSpeech/source/Widgets.lua
+++ b/reascripts/ReaSpeech/source/Widgets.lua
@@ -88,6 +88,5 @@ function Widgets.tooltip(text)
 end
 
 function Widgets.warning(text)
-  local bold_red = 0xff0000ff
-  ImGui.TextColored(ctx, bold_red, text)
+  ImGui.TextColored(ctx, Theme.COLORS.bold_red, text)
 end

--- a/reascripts/common/libs/PathUtil.lua
+++ b/reascripts/common/libs/PathUtil.lua
@@ -35,6 +35,11 @@ PathUtil.apply_extension = function(filepath, extension)
   return filepath .. '.' .. extension
 end
 
+-- Returns the filename+extension portion of a full path.
+PathUtil.get_filename = function(filepath)
+  return filepath:match("[^\\/]*$")
+end
+
 -- Returns the given path if a full path, otherwise returns given path
 -- relative to the REAPER project resource directory.
 PathUtil.get_real_path = function(path_arg)

--- a/reascripts/common/libs/PathUtil.lua
+++ b/reascripts/common/libs/PathUtil.lua
@@ -6,6 +6,11 @@
 
 PathUtil = {}
 
+-- Returns true if the given file path has an extension, false otherwise.
+PathUtil.has_extension = function(filepath)
+  return filepath:find("%.[^%.\\/%s]*$") and true or false
+end
+
 -- Apply an extension to a file path, if it doesn't already have one.
 -- Empty or nil path returns the empty string.
 PathUtil.apply_extension = function(filepath, extension)
@@ -33,7 +38,7 @@ end
 -- Returns the given path if a full path, otherwise returns given path
 -- relative to the REAPER project resource directory.
 PathUtil.get_real_path = function(path_arg)
-  if PathUtil._is_full_path(path_arg) then
+  if PathUtil.is_full_path(path_arg) then
     return path_arg
   end
 
@@ -53,7 +58,8 @@ PathUtil.get_reveal_command = function(path_arg)
   end
 end
 
-PathUtil._is_full_path = function(path)
+-- Returns true if the given path is a full path, false otherwise.
+PathUtil.is_full_path = function(path)
   local found
 
   if EnvUtil.is_windows() then

--- a/reascripts/common/libs/PathUtil.lua
+++ b/reascripts/common/libs/PathUtil.lua
@@ -76,6 +76,16 @@ PathUtil.is_full_path = function(path)
   return found and true or false
 end
 
+-- Joins an arbitrary list of path components into a single path
+-- using the appropriate path separator for the current OS
+-- (as reported by REAPER, anyway).
+PathUtil.join = function(...)
+  local args = {...}
+  local separator = PathUtil._path_separator()
+
+  return table.concat(args, separator)
+end
+
 PathUtil._path_separator = function()
   if EnvUtil.is_windows() then
     return "\\"

--- a/reascripts/common/tests/TestPathUtil.lua
+++ b/reascripts/common/tests/TestPathUtil.lua
@@ -184,4 +184,22 @@ function TestPathUtil:testPathSeparator()
   end
 end
 
+function TestPathUtil:testGetFilename()
+  local file_paths = {
+    "C:\\path\\to\\some-file.json",
+    "path\\to\\some-file.json",
+    "\\Server\\Volume\\some-file.json",
+    "/path/to/some-file.json",
+    "path/to/some-file.json",
+    "some-file.json",
+  }
+
+  for _, p in ipairs(file_paths) do
+    lu.assertEquals(PathUtil.get_filename(p), 'some-file.json')
+  end
+
+  -- blank is blank
+  lu.assertEquals(PathUtil.get_filename(""), "")
+end
+
 os.exit(lu.LuaUnit.run())

--- a/reascripts/common/tests/TestPathUtil.lua
+++ b/reascripts/common/tests/TestPathUtil.lua
@@ -202,4 +202,22 @@ function TestPathUtil:testGetFilename()
   lu.assertEquals(PathUtil.get_filename(""), "")
 end
 
+function TestPathUtil:testJoin()
+  reaper.GetOS = function() return "Win64" end
+
+  lu.assertEquals(PathUtil.join("path", "to", "some-file.json"), "path\\to\\some-file.json")
+
+  reaper.GetOS = function() return "OSX64" end
+
+  lu.assertEquals(PathUtil.join("path", "to", "some-file.json"), "path/to/some-file.json")
+
+  reaper.GetOS = function() return "Other" end
+
+  lu.assertEquals(PathUtil.join("path", "to", "some-file.json"), "path/to/some-file.json")
+
+  lu.assertEquals(PathUtil.join(), "")
+  lu.assertEquals(PathUtil.join("one-arg"), "one-arg")
+
+end
+
 os.exit(lu.LuaUnit.run())

--- a/reascripts/common/tests/TestPathUtil.lua
+++ b/reascripts/common/tests/TestPathUtil.lua
@@ -14,6 +14,24 @@ reaper = {
   GetProjectPath = function() return TestPathUtil.PROJECT_PATH end,
 }
 
+function TestPathUtil:testHasExtension()
+  lu.assertTrue(PathUtil.has_extension("some-file.json"))
+  lu.assertTrue(PathUtil.has_extension("path\\to\\some-file.json"))
+  lu.assertTrue(PathUtil.has_extension("path/to/some-file.json"))
+  lu.assertTrue(PathUtil.has_extension("C:\\path\\to\\some-file.json"))
+  lu.assertTrue(PathUtil.has_extension("/path/to/some-file.json"))
+
+  lu.assertFalse(PathUtil.has_extension("some-file"))
+  lu.assertFalse(PathUtil.has_extension("path\\to\\some-file"))
+  lu.assertFalse(PathUtil.has_extension("path/to/some-file"))
+  lu.assertFalse(PathUtil.has_extension("C:\\path\\to\\some-file"))
+  lu.assertFalse(PathUtil.has_extension("/path/to/some-file"))
+
+  lu.assertTrue(PathUtil.has_extension(".json"))
+  lu.assertFalse(PathUtil.has_extension(""))
+
+end
+
 function TestPathUtil:testApplyExtension()
   local extension = "json"
 
@@ -125,7 +143,7 @@ function TestPathUtil:testIsFullPath()
 
   for expected, path in pairs(assertions) do
     for _, p in ipairs(path) do
-      lu.assertEquals(PathUtil._is_full_path(p), expected)
+      lu.assertEquals(PathUtil.is_full_path(p), expected)
     end
   end
 
@@ -143,7 +161,7 @@ function TestPathUtil:testIsFullPath()
 
     for expected, path in pairs(assertions) do
       for _, p in ipairs(path) do
-        lu.assertEquals(PathUtil._is_full_path(p), expected)
+        lu.assertEquals(PathUtil.is_full_path(p), expected)
       end
     end
   end


### PR DESCRIPTION
This adds a checkbox and conditionally some target filename-related text under the file selector & "Choose file" button in `TranscriptExporter`.

If no full path is provided, it'll be relative to the active REAPER project's resource path.

On success, the alert popup now shows the filename-portion of the exported path. That filename is a "reveal" link which will attempt to open & focus the file in a platform-dependent way before closing the popup.

This is a work-in-progress whose full scope might be more than just this PR. Mainly just trying to start addressing general UX around this feature.

Closes #104.

quick demo:

https://github.com/user-attachments/assets/0e2ba0d2-75cd-40a3-b24d-8f94388e22aa




