### PR TITLE
Ignore keyboard events on edit window when an input is active

### DIFF
--- a/reascripts/ReaSpeech/source/ui/TranscriptEditor.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptEditor.lua
@@ -77,7 +77,10 @@ function TranscriptEditor:edit_word(index)
 end
 
 function TranscriptEditor:render_content()
-  self.key_bindings:react()
+  if not ImGui.IsAnyItemActive(ctx) then
+    self.key_bindings:react()
+  end
+
   if self.editing.word then
     self:render_word_navigation()
     self:render_separator()


### PR DESCRIPTION
In the edit window, if you click on an input (like the word's text input) and then press the right arrow key, it navigates to the next word, and overwrites the contents of that word. This change disables the custom keyboard handling when an input is in use.