### PR TITLE
Only depend on Lua 5.4 for default run.py target

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -32,6 +32,9 @@ argmap = {
     '--build-reascripts': {
         'action': 'store_true',
         'help': 'Build ReaScripts before starting' },
+    '--build-reascripts-target': {
+        'default': 'publish5.4',
+        'help': 'ReaScripts build target (default: %(default)s)' },
     '--enable-swagger-ui': {
         'action': 'store_true',
         'help': 'Enable automatic Swagger UI for API' },
@@ -52,7 +55,8 @@ os.environ['ASR_ENGINE'] = args.asr_engine
 os.environ['ASR_MODEL'] = args.asr_model
 
 if args.build_reascripts:
-    if os.system('cd reascripts/ReaSpeech && make') != 0:
+    print('Building ReaScripts...', file=sys.stderr)
+    if os.system(f'cd reascripts/ReaSpeech && make {args.build_reascripts_target}') != 0:
         print('ReaScript build failed', file=sys.stderr)
         sys.exit(1)
 

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -6,7 +6,7 @@ services:
       args:
         - SERVICE_UID
         - SERVICE_GID
-    entrypoint: ["python3", "app/run.py", "--build-reascripts"]
+    entrypoint: ["python3", "app/run.py", "--build-reascripts", "--build-reascripts-target=all"]
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         - SERVICE_UID
         - SERVICE_GID
-    entrypoint: ["python3", "app/run.py", "--build-reascripts"]
+    entrypoint: ["python3", "app/run.py", "--build-reascripts", "--build-reascripts-target=all"]
     environment:
       - ASR_ENGINE=faster_whisper
     ports:

--- a/reascripts/ReaSpeech/Makefile
+++ b/reascripts/ReaSpeech/Makefile
@@ -59,10 +59,16 @@ build/ReaSpeech-5.3.luac: $(BUNDLE_TARGET)
 build/ReaSpeech-5.4.luac: $(BUNDLE_TARGET)
 	$(LUAC54) -o build/ReaSpeech-5.4.luac -s $(BUNDLE_TARGET)
 
-.PHONY: publish
-publish: build
+.PHONY: publish5.3
+publish5.3: build/ReaSpeech-5.3.luac
 	cp build/ReaSpeech-5.3.luac $(dest)/
+
+.PHONY: publish5.4
+publish5.4: build/ReaSpeech-5.4.luac
 	cp build/ReaSpeech-5.4.luac $(dest)/
+
+.PHONY: publish
+publish: publish5.3 publish5.4
 
 .PHONY: tags
 tags : tagged_paths = $(SOURCE_ROOT)


### PR DESCRIPTION
When using run.py from the command line, it is inconvenient to need two Lua versions (we support Lua 5.3 for REAPER 6 users). In addition, the linter/tests may not be necessary if a user just wants to run ReaSpeech from the git repository without using Docker. This change adjusts the Makefile to enable publishing for specific Lua versions, adjusts run.py to publish for Lua 5.4 by default, and re-enables all tests and Lua versions in Docker Compose environments.

Hopefully this will not mess up the release process. @mikeylove please let me know if anything stands out.