### PR TITLE
Skip normal TranscriptImporter flow if selection made via file browser

### DIFF
--- a/reascripts/ReaSpeech/.luacheckrc
+++ b/reascripts/ReaSpeech/.luacheckrc
@@ -9,6 +9,7 @@ globals = {
   "reaper",
   "ReaUtil",
   "Script",
+  "string",
   "table",
   "ToolWindow",
   "url",

--- a/reascripts/ReaSpeech/source/libs/StringUtils.lua
+++ b/reascripts/ReaSpeech/source/libs/StringUtils.lua
@@ -1,0 +1,17 @@
+--[[
+
+    StringUtils.lua - miscellaneous string utiilities
+
+]]--
+
+string.split = string.split or function(str, sep)
+  local result = {}
+
+  local pattern = ("([^%s]*)"):format(sep)
+
+  for match in str:gmatch(pattern) do
+    table.insert(result, match)
+  end
+
+  return result
+end

--- a/reascripts/ReaSpeech/source/ui/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ui/ASRActions.lua
@@ -103,10 +103,31 @@ function ASRActions:import_button()
 
   self._import_button = Widgets.Button.new({
     label = "Import Transcript",
-    on_click = function () app.importer:present() end
+    on_click = self._import_click
   })
 
   return self._import_button
+end
+
+ASRActions._import_click = function()
+  local filenames = Widgets.FileSelector.simple_open(
+    'Import Transcript',
+    { json = 'JSON Files' }
+  )
+
+  if #filenames < 1 then
+    app.importer:present()
+    return
+  end
+
+  -- only considering one selection for the moment
+  local selection = filenames[1]
+
+  local _, err = app.importer:import(selection)
+
+  if err then
+    app.importer:present()
+  end
 end
 
 function ASRActions.pluralizer(count, suffix)

--- a/reascripts/ReaSpeech/source/ui/widgets/FileSelector.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/FileSelector.lua
@@ -55,6 +55,36 @@ FileSelector.new = function(options)
   return o
 end
 
+FileSelector.simple_open = function(title, extension_table, extra_config)
+  if not FileSelector.has_js_ReaScriptAPI() then
+    return {}
+  end
+
+  extra_config = extra_config or {}
+
+  title = title or 'Open file(s)'
+  local initial_folder = extra_config.initial_folder or ''
+  local initial_file = extra_config.initial_file or ''
+  local allow_multiple = extra_config.allow_multiple or false
+
+  local extension_pairs = {}
+  for ext, pretty in pairs(extension_table) do
+    local extensions = ("*.%s"):format(table.concat(ext:split(','), ';*.'))
+
+    table.insert(extension_pairs, ("%s\0%s"):format(pretty, extensions))
+  end
+  local extension_string = table.concat(extension_pairs, '\0') .. '\0'
+
+  local selection_made, files = reaper.JS_Dialog_BrowseForOpenFiles(
+    title, initial_folder, initial_file, extension_string, allow_multiple)
+
+  if selection_made < 1 then
+    return {}
+  end
+
+  return files:split('\0')
+end
+
 -- Display a text input for the output filename, with a Browse button if
 -- the js_ReaScriptAPI extension is available.
 FileSelector.renderer = function(self)

--- a/reascripts/ReaSpeech/tests/libs/TestStringUtils.lua
+++ b/reascripts/ReaSpeech/tests/libs/TestStringUtils.lua
@@ -1,0 +1,31 @@
+package.path = 'source/?.lua;' .. package.path
+
+local lu = require('vendor/luaunit')
+
+require('libs/StringUtils')
+
+--
+
+TestStringUtils = {}
+
+function TestStringUtils:testSplitMethodExists()
+  lu.assertNotNil(string['split'])
+  lu.assertEquals(type(string['split']), 'function')
+end
+
+function TestStringUtils:testSplit()
+  local expectations = {
+    [{'oh,hello,there', ','}] = {'oh', 'hello', 'there'},
+    [{'oh, hello, there', ','}] = {'oh', ' hello', ' there'},
+    [{',oh, hello, there ,', ','}] = {'', 'oh', ' hello', ' there ', ''},
+    [{'oh,hello,there', ';'}] = {'oh,hello,there'},
+    [{'oh;hello;there', ';'}] = {'oh', 'hello', 'there'},
+  }
+
+  for input, expected in pairs(expectations) do
+    local result = input[1]:split(input[2])
+    lu.assertEquals(result, expected)
+  end
+end
+
+os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
If the user has `js_ReaScriptAPI`, this will immediately pop open a file browser when "Import Transcript" is clicked. If a selection is made, that transcript is loaded and there is no further confirmation or prompt. If there's no selection or an error importing, the importer loads as it normally does and the user can try again from there.

This aims to get at some of what @smrl was [pointing out](https://github.com/TeamAudio/reaspeech/pull/134#issuecomment-2578857396):

> When an imported transcript appears as a new tab that may be enough suggestion to the user that import was successful, and then we don't need that dialog.

That PR is still open at time of this writing, but this change should be pretty easy to apply over there too. 

https://github.com/user-attachments/assets/171e7fc3-1af6-44c0-b6ca-36bc08391001


