### PR TITLE
More gracefully handle when backend isn't running

### DIFF
--- a/reascripts/ReaSpeech/source/libs/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/libs/CurlRequest.lua
@@ -31,6 +31,10 @@ function CurlRequest._init()
     DEFAULT_ERROR_HANDLER = function(_msg) end,
     DEFAULT_TIMEOUT_HANDLER = function() end,
     SENTINEL = '-=-DONE-=-',
+
+    CURL_ERRORS = {
+      [7] = "Couldn't connect to host. Is your ReaSpeech backend running?"
+    },
   }
 
   function API.async(options)
@@ -218,10 +222,17 @@ function CurlRequest._init()
   function API:execute_async(command)
     local executor = ExecProcess.new(command)
 
-    if not executor:background() then
+    local result = executor:background()
+    local result_code = tonumber(result:match("(-?%d+)\n"))
+
+    if not result then
       local err = "Unable to run curl"
       self:log(err)
       self.error_handler(err)
+    elseif result_code > 0 then
+      self.error_msg = self.curl_message(result_code)
+      self:log(self.error_msg)
+      self.error_handler(self.error_msg)
     end
 
     return self
@@ -322,6 +333,25 @@ function CurlRequest._init()
     return { '-m', self.curl_timeout }
   end
 
+  function API:check_curl_error(progress_contents)
+    local err = progress_contents:match("^curl: %((-?%d+)%).*")
+
+    if err then
+      self:debug("Curl Error #" .. err)
+      return tonumber(err)
+    end
+
+    return false
+  end
+
+  API.curl_message = function(err_num)
+    if API.CURL_ERRORS[err_num] then
+      return API.CURL_ERRORS[err_num]
+    end
+
+    return "Curl Error #" .. err_num
+  end
+
   function API:check_sentinel()
     local sentinel = io.open(self.progress_file, 'r')
 
@@ -331,6 +361,12 @@ function CurlRequest._init()
 
     local contents = sentinel:read("*all")
     sentinel:close()
+
+    local curl_err = self:check_curl_error(contents)
+    if curl_err then
+      self.error_msg = self.curl_message(curl_err)
+      return false
+    end
 
     -- Workaround for https://github.com/curl/curl/issues/10491
     local version = API.curl_version()


### PR DESCRIPTION
The progress file and sentinel check in `CurlRequest` weren't really handling the case where there was a generic curl error (like `(7) Failed to connect to host.`).

Now, the request's error state should be updated, enabling a friendly popup instead.

`ASRControls` will now show a modal alert when this happens, and clicking "OK" or closing that will try again. Same for generating a transcript, except that dismissing the alert won't immediately try again. Both cases seem to work fairly seamlessly when the backend is started up in between attempts.

Fixes #77...to some degree