### PR TITLE
Localized Strings

### DIFF
--- a/reascripts/ReaSpeech/source/libs/TableUtils.lua
+++ b/reascripts/ReaSpeech/source/libs/TableUtils.lua
@@ -17,3 +17,13 @@ table.flatten = table.flatten or function(tables)
 
   return result
 end
+
+table.shallow_clone = table.shallow_clone or function(t)
+  local clone = {}
+
+  for k, v in pairs(t) do
+    clone[k] = v
+  end
+
+  return clone
+end

--- a/reascripts/ReaSpeech/source/libs/TableUtils.lua
+++ b/reascripts/ReaSpeech/source/libs/TableUtils.lua
@@ -4,7 +4,7 @@
 
 ]]--
 
-table.flatten = table.flatten or function(tables)
+table.flatten = function(tables)
   local result = {}
 
   for _, t in ipairs(tables or {}) do
@@ -18,7 +18,7 @@ table.flatten = table.flatten or function(tables)
   return result
 end
 
-table.shallow_clone = table.shallow_clone or function(t)
+table.shallow_clone = function(t)
   local clone = {}
 
   for k, v in pairs(t) do

--- a/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
@@ -28,6 +28,7 @@ function ReaSpeechMain:loop()
     if app:presenting() or app:is_open() then
       ctx = Ctx()
       Fonts:check(ctx)
+      Locale:check()
       Trap(function() app:react() end)
       reaper.defer(self:loop())
     end

--- a/reascripts/ReaSpeech/source/ui/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ui/ASRActions.lua
@@ -16,9 +16,12 @@ ASRActions = PluginActions {
 }
 
 function ASRActions:init()
-  assert(self.plugin, 'ASRActions: plugin is required')
+  self.strings = function() return Locale().plugins.asr.actions end
+
+  assert(self.plugin, 'ASRActions: ' .. self.strings().assert_plugin)
 
   Logging().init(self, 'ASRActions')
+
 end
 
 function ASRActions:selected_tracks_button()
@@ -32,17 +35,20 @@ function ASRActions:selected_tracks_button()
 
   if selected_track_count == 0 then
     self._selected_tracks_button = Widgets.Button.new({
-      label = "Process Selected Tracks",
+      label = function()
+        return self.strings().selected_tracks_label
+      end,
       disabled = true,
     })
     return self._selected_tracks_button
   end
 
-  local button_text = ("Process %sSelected Track%s")
-    :format(self.pluralizer(selected_track_count, 's'))
-
   self._selected_tracks_button = Widgets.Button.new({
-    label = button_text,
+    label = function()
+      -- almost certainly wrong for many languages
+      return self.strings().selected_tracks_format
+        :format(self.pluralizer(selected_track_count, 's'))
+    end,
     on_click = function ()
       self:process_jobs(self.jobs_for_selected_tracks)
     end,
@@ -62,17 +68,20 @@ function ASRActions:selected_items_button()
 
   if selected_item_count == 0 then
     self._selected_items_button = Widgets.Button.new({
-      label = "Process Selected Items",
+      label = function()
+        return self.strings().selected_items_label
+      end,
       disabled = true,
     })
     return self._selected_items_button
   end
 
-  local button_text = ("Process %sSelected Item%s")
-    :format(self.pluralizer(selected_item_count, 's'))
-
   self._selected_items_button = Widgets.Button.new({
-    label = button_text,
+    label = function()
+      -- almost certainly wrong for many languages
+      return self.strings().selected_items_format
+        :format(self.pluralizer(selected_item_count, 's'))
+    end,
     on_click = function ()
       self:process_jobs(self.jobs_for_selected_items)
     end,
@@ -87,7 +96,9 @@ function ASRActions:all_items_button()
   end
 
   self._all_items_button = Widgets.Button.new({
-    label = "Process All Items",
+    label = function()
+      return self.strings().all_items_label
+    end,
     on_click = function ()
       self:process_jobs(self.jobs_for_all_items)
     end,
@@ -102,7 +113,9 @@ function ASRActions:import_button()
   end
 
   self._import_button = Widgets.Button.new({
-    label = "Import Transcript",
+    label = function()
+      return self.strings().import_label
+    end,
     on_click = function () app.importer:present() end
   })
 
@@ -123,7 +136,7 @@ function ASRActions:process_jobs(job_generator)
   local jobs = job_generator()
 
   if #jobs == 0 then
-    reaper.MB("No media found to process.", "No media", 0)
+    reaper.MB(self.strings().no_media_text, self.strings().no_media_title, 0)
     return
   end
 

--- a/reascripts/ReaSpeech/source/ui/Locale.lua
+++ b/reascripts/ReaSpeech/source/ui/Locale.lua
@@ -1,0 +1,44 @@
+--[[
+
+  Locale.lua - accessor for loaded locale
+
+]]--
+
+Locale = setmetatable({}, {
+  __call = function(self)
+    if self._locale then
+      return self._locale
+    end
+
+    self:init()
+
+    return self._locale
+  end
+})
+
+
+function Locale:init()
+
+  local storage = Storage.ExtState.make {
+    section = 'ReaSpeech.General',
+    persist = true,
+  }
+
+  self.locale = storage:string('locale', 'en')
+
+  self._last_locale = self.locale:get()
+
+  self._locale = Strings.localize(self._last_locale)
+end
+
+function Locale:check()
+  local current_locale = self.locale:get()
+
+  if current_locale == self._last_locale then
+    return
+  end
+
+  self._last_locale = current_locale
+
+  self._locale = Strings.localize(current_locale)
+end

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechWidgets.lua
@@ -35,6 +35,10 @@ function ReaSpeechWidget:render_label(label)
   local options = self.options
   label = label or options.label
 
+  if type(label) == 'function' then
+    label = label()
+  end
+
   ImGui.Text(ctx, label)
 
   if label ~= '' and options.help_text then

--- a/reascripts/ReaSpeech/source/ui/SettingsControls.lua
+++ b/reascripts/ReaSpeech/source/ui/SettingsControls.lua
@@ -23,11 +23,39 @@ function SettingsControls:init()
   }
 
   self:init_logging()
+
+  local storage = Storage.ExtState.make {
+    section = 'ReaSpeech.General',
+    persist = true,
+  }
+
+  local languages = Strings.available_languages()
+  local language_list = {}
+  local language_map = {}
+
+  for tag, name in pairs(languages) do
+    table.insert(language_list, tag)
+    language_map[tag] = name
+  end
+
+  self.locale = Widgets.Combo.new {
+    state = storage:string('locale', 'en'),
+    label = function()
+      return Locale().plugins.settings.controls.locale_label
+    end,
+    items = language_list,
+    item_labels = language_map,
+  }
+
   self:init_layout()
 end
 
 function SettingsControls:init_layout()
-  local renderers = { self.render_font_size, self.render_logging }
+  local renderers = {
+    self.render_font_size,
+    self.render_logging,
+    self.render_locale
+  }
 
   self.layout = ColumnLayout.new {
     column_padding = ReaSpeechControlsUI.COLUMN_PADDING,
@@ -83,4 +111,8 @@ function SettingsControls:render_logging()
   disable_if(not self.log_enable:value(), function ()
     self.log_debug:render()
   end)
+end
+
+function SettingsControls:render_locale()
+  self.locale:render()
 end

--- a/reascripts/ReaSpeech/source/ui/SettingsControls.lua
+++ b/reascripts/ReaSpeech/source/ui/SettingsControls.lua
@@ -14,12 +14,14 @@ SettingsControls = PluginControls {
 }
 
 function SettingsControls:init()
-  assert(self.plugin, 'SettingsControls: plugin is required')
+  assert(self.plugin, 'SettingsControls: ' .. Locale().plugins.settings.controls.assert_plugin)
   Logging().init(self, 'SettingsControls')
 
   self.font_size = Widgets.NumberInput.new {
     state = Fonts.size,
-    label = 'Font Size',
+    label = function()
+      return Locale().plugins.settings.controls.font_size_label
+    end,
   }
 
   self:init_logging()
@@ -85,14 +87,22 @@ function SettingsControls:init_logging()
 
   self.log_enable = Widgets.Checkbox.new {
     state = Logging().show_logs,
-    label_long = 'Enable',
-    label_short = 'Enable',
+    label_long = function()
+      return Locale().plugins.settings.controls.logging_basic_long
+    end,
+    label_short = function()
+      return Locale().plugins.settings.controls.logging_basic_short
+    end,
   }
 
   self.log_debug = Widgets.Checkbox.new {
     state = Logging().show_debug_logs,
-    label_long = 'Debug',
-    label_short = 'Debug',
+    label_long = function()
+      return Locale().plugins.settings.controls.logging_debug_long
+    end,
+    label_short = function()
+      return Locale().plugins.settings.controls.logging_debug_short
+    end,
   }
 end
 
@@ -103,7 +113,9 @@ end
 function SettingsControls:render_logging()
   local disable_if = ReaUtil.disabler(ctx)
 
-  ReaSpeechControlsUI:render_input_label('Logging')
+  ReaSpeechControlsUI:render_input_label(
+    Locale().plugins.settings.controls.logging_label
+  )
 
   self.log_enable:render()
   ImGui.SameLine(ctx)

--- a/reascripts/ReaSpeech/source/ui/Strings.lua
+++ b/reascripts/ReaSpeech/source/ui/Strings.lua
@@ -63,13 +63,15 @@ Strings.indexer = function(strs, key, fallback)
 end
 
 Strings.available_languages = function()
+  if Strings._available_languages then return Strings._available_languages end
+
   local languages = {}
 
   for language, definition in pairs(Strings) do
     if language:match('^%a%a$') then
       -- look for base level definition
       if definition._name then
-        table.insert(languages, { language, definition._name })
+        languages[language] = definition._name
       end
 
       -- look for regional definitions
@@ -77,12 +79,13 @@ Strings.available_languages = function()
         if region:match('^%a%a$') then
           if region_definition._name then
             local tag = ('%s-%s'):format(language, region)
-            table.insert(languages, { tag, region_definition._name })
+            languages[tag] = region_definition._name
           end
         end
       end
     end
   end
 
+  Strings._available_languages = languages
   return languages
 end

--- a/reascripts/ReaSpeech/source/ui/Strings.lua
+++ b/reascripts/ReaSpeech/source/ui/Strings.lua
@@ -1,0 +1,88 @@
+--[[
+
+  Strings.lua - module to use localization definitions
+
+]]--
+
+Strings = {}
+
+Strings.localize = function(tag)
+  local language, region = tag:match('^(%a%a)-(%a%a)$')
+
+  if not language then
+    language = tag:match('^(%a%a)$')
+  end
+
+  if not language then
+    language = 'en'
+    region = 'US'
+  end
+
+  if not Strings[language] then
+    assert('invalid language: ' .. dump(language))
+  end
+
+  strings = Strings[language]
+
+  if region then
+    if not strings[region] then
+      assert('invalid region: ' .. dump(region))
+    end
+
+    strings = strings[region]
+  end
+
+  local fallback = function(_) return nil end
+  if strings._fallback then
+    fallback = function(key)
+      return Strings.localize(strings._fallback)[key]
+    end
+  end
+
+  return setmetatable({}, {
+    __index = function(_, key)
+      return Strings.indexer(strings._strings or {}, key, fallback)
+    end
+  })
+end
+
+Strings.indexer = function(strs, key, fallback)
+  if strs[key] then
+    if type(strs[key]) == 'table' then
+      return setmetatable({}, {
+        __index = function(_, key1)
+          return Strings.indexer(strs[key] or {}, key1)
+        end
+      })
+    end
+
+    return strs[key]
+  else
+    return fallback(key)
+  end
+end
+
+Strings.available_languages = function()
+  local languages = {}
+
+  for language, definition in pairs(Strings) do
+    if language:match('^%a%a$') then
+      -- look for base level definition
+      if definition._name then
+        table.insert(languages, { language, definition._name })
+      end
+
+      -- look for regional definitions
+      for region, region_definition in pairs(definition) do
+        if region:match('^%a%a$') then
+          if region_definition._name then
+            local tag = ('%s-%s'):format(language, region)
+            table.insert(languages, { tag, region_definition._name })
+          end
+        end
+      end
+    end
+  end
+
+  return languages
+end

--- a/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
+++ b/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
@@ -1,0 +1,380 @@
+--[[
+
+    Strings.en.lua - English localization strings
+
+]] --
+
+Strings = Strings or {}
+
+Strings.en = {
+  _name = "English",
+  _fallback = nil,
+
+  AU = {
+    _name = "Australian English",
+    _fallback = "en",
+  },
+
+  CA = {
+    _name = "Canadian English",
+    _fallback = "en",
+  },
+
+  GB = {
+    _name = "British English",
+    _fallback = "en",
+    _strings = {
+      color_or_colour = "colour",
+    },
+  },
+
+  IE = {
+    _name = "Irish English",
+    _fallback = "en",
+  },
+
+  IN = {
+    _name = "Indian English",
+    _fallback = "en",
+  },
+
+  NZ = {
+    _name = "New Zealand English",
+    _fallback = "en",
+  },
+
+  SG = {
+    _name = "Singaporean English",
+    _fallback = "en",
+  },
+
+  US = {
+    _name = "American English",
+    _fallback = "en",
+  },
+
+  ZA = {
+    _name = "South African English",
+    _fallback = "en",
+  },
+
+  _strings = {
+    color_or_colour = "color",
+    libs = {
+      ctx = { -- Ctx
+        label = "Application",
+      },
+      curl_request = { -- CurlRequest
+        assert_url = "missing url",
+        debug_sentinel = "Sentinel found, parsing response",
+        debug_opening_output = "Couldn't open output file:",
+        debug_trying_again_later = "trying again later",
+        error_msg_server_responded_with = "Server responded with status",
+        error_msg_empty_response = "Empty response",
+        error_msg_json_parsing = "JSON parse error",
+        error_msg_progress_file = "Unable to open progress file",
+        error_msg_no_curl = "Unable to run curl",
+        debug_curl_timeout = "Curl timeout reached",
+        error_msg_curl_failed = "Curl failed with status",
+        error_msg_request_failed = "Request failed with status",
+        debug_checking_sentinel = "Checking sentinel",
+        error_status_not_found = "Status not found in headers",
+      },
+      exec_process = { -- ExecProcess
+        error_no_tempfile = "Unable to open tempfile",
+      },
+      logging = { -- Logging
+        basic_tag = "LOG",
+        debug_tag = "DEBUG",
+      },
+      storage = { -- Storage
+        assert_section = "missing section",
+        assert_project = "missing project",
+        assert_extname = "missing extname",
+      },
+      tool_window = { -- ToolWindow
+        default_title = "Tool Window",
+      },
+    },
+    main = { -- main/*.lua, ReaSpeechMain
+      imgui_required =
+      "This script requires the ReaImGui API, which can be installed from:\n\nExtensions > ReaPack > Browse packages...",
+      imgui_required_title = "ReaImGui required",
+      csv_writer = { -- CSVWriter
+        delimiter_comma = "Comma",
+        delimiter_semicolon = "Semicolon",
+        delimiter_tab = "Tab",
+        assert_file = "missing file",
+        header_sequence_number = "Sequence Number",
+        header_start_time = "Start Time",
+        header_end_time = "End Time",
+        header_text = "Text",
+        header_file = "File",
+        time_format = "%02d:%02d:%02d,%03d",
+      },
+      srt_writer = { -- SRTWriter
+        assert_file = "missing file",
+        time_format = "%02d:%02d:%02d,%03d",
+      },
+      transcript_segment = { -- TranscriptSegment
+        assert_data = "missing data",
+        assert_item = "missing item",
+        assert_take = "missing take",
+      },
+      transcript_word = { -- TranscriptWord
+        assert_word = "missing word",
+        assert_start = "missing start",
+        assert_end = "missing end_",
+        assert_probability = "missing probability",
+      },
+      worker = { -- ReaSpeechWorker
+        assert_requests = "missing requests",
+        assert_responses = "missing responses",
+        log_processing_finished = "Processing finished",
+        sending_media = "Sending Media",
+        log_processing = "Processing speech...",
+        debug_active_job = "Active job",
+        debug_status = "Status",
+
+      },
+    },
+    ui = {
+      transcription_failed = "Transcription failed",            -- ReaSpeechUI
+      assert_endpoint = "Endpoint required for API call",       -- ReaSpeechUI
+      alert = { -- AlertPopup
+        default_title = "Alert",
+        ok_button = "OK",
+      },
+      actions = { -- ReaSpeechActionsUI
+        cancel_button = "Cancel",
+      },
+      annotations = { -- TranscriptAnnotations
+        assert_transcript = "transcript is required",
+        notes_track_default_name = "Speech",
+
+        ui = { -- TranscriptAnnotationsUI
+          title = "Transcript Annotations",
+          assert_transcript = "transcript is required",
+          create_button = "Create",
+          close_button = "Close",
+          segment_label = "Segment",
+          word_label = "Word",
+          granularity_label = "Granularity",
+          track_filter_mode_label = "Track Filter Mode",
+          include_button = "Include",
+          ignore_button = "Ignore",
+          track_selector_label = "Track Filter",
+          take_markers_label = "Take Markers",
+          take_markers_undo_label = "Create take markers from transcript",
+          project_markers_label = "Project Markers",
+          project_markers_undo_label = "Create project markers from transcript",
+          project_regions_label = "Project Regions",
+          project_regions_undo_label = "Create project regions from transcript",
+          notes_track_track_name = "Transcript",
+          notes_track_track_name_label = "Track Name",
+          notes_track_undo_label = "Create notes track from transcript",
+        }
+      },
+      column_layout = { -- ColumnLayout
+        assert_renderer = "render_column function must be provided",
+      },
+      controls = { -- ReaSpeechControlsUI
+        assert_plugins = "plugins is required",
+      },
+      editor = { -- TranscriptEditor
+        title = "Edit Segment",
+        zoom_none = "None",
+        zoom_word = "Word",
+        zoom_segment = "Segment",
+        assert_transcript = "missing transcript",
+        save_button = "Save",
+        cancel_button = "Cancel",
+        add_button = "Add",
+        add_button_tooltip = "Add word after current word",
+        delete_button = "Delete",
+        delete_button_tooltip = "Delete current word",
+        split_button = "Split",
+        split_button_tooltip = "Split current word into two words",
+        merge_button = "Merge",
+        merge_button_tooltip = "Merge current word with next word",
+        time_start_label = "start",
+        time_end_label = "end",
+        word_label = "word",
+        score_label = "score",
+        play_word_tooltip = "Play word",
+        stop_tooltip = "Stop",
+        sync_time_label = "sync time selection",
+        sync_zoom_conjunction = "and",
+        zoom_to_label = "zoom to",
+
+      },
+      exporter = { -- TranscriptExporter
+        title = "Export",
+        assert_transcript = "missing transcript",
+        apply_extension_label = "Apply Extension",
+        project_resources_label = "Project Resources",
+        success_title = "Export Successful",
+        success_text_format = "Exported %s to:",
+        fail_title = "Export Failed",
+        target_file_label = "Target File",
+        file_exists_warning = "File exists and will be overwritten.",
+        export_button = "Export",
+        cancel_button = "Cancel",
+        error_missing_file = "Please specify a file name.",
+        error_opening_file = "Could not open file:",
+        format_label = "Format",
+        debug_no_available_formats = "no formats to set for default",
+        all_files_label = "All files",
+        json_one_object_per_label = "One Object per Transcript Segment",
+        csv_delimiter_label = "Delimiter",
+        csv_include_header_label = "Include Header Row",
+
+      },
+      globals = { -- includes/globals.lua
+        cirular_reference = "Circular reference detected",
+      },
+      importer = { -- TranscriptImporter
+        title = "Import",
+        assert_file_type = "File - must be JSON previously exported from ReaSpeech",
+        success_title = "Import Successful",
+        success_text_format = "Imported %s",
+        fail_title = "Import Failed",
+        import_button = "Import",
+        no_file_selected = "No file selected",
+        close_button = "Close",
+        file_not_found = "File not found",
+
+      },
+      plugins = { -- ReaSpeechPlugins
+        assert_app = "plugin host app is required",
+        assert_plugins = "plugins is required",
+      },
+      transcript_ui = { -- TranscriptUI
+        title = "Transcript",
+        assert_transcript = "missing transcript",
+        separator_text = "Transcript",
+        create_markers_button = "Create Markers",
+        export_button = "Export",
+        clear_button = "Clear",
+        auto_play_label = "Auto Play",
+        words_label = "Words",
+        colorize_label = "Colorize",
+        search_hint = "Search",
+        edit_tooltip = "Edit",
+        -- how to handle transcript columns?
+
+      },
+      welcome = { -- ReaSpeechWelcomeUI
+        title = "Welcome!",
+        heading = "Welcome to ReaSpeech!",
+        text = "This is a tool for transcribing audio in REAPER.",
+        demo_heading = "Demo Version",
+        demo_text = { "Please note that this version is a demo and may not be available at all times.",
+          "For a more reliable experience, you can run ReaSpeech locally using the ",
+          "ReaSpeechWelcomeUI.DOCKER_HUB_URL",
+          "Docker image." },
+        button = "Let's Go!",
+        website_link = { "ReaSpeechWelcomeUI.HOME_URL", "ReaSpeech Website" },
+        github_link = { "ReaSpeechWelcomeUI.GITHUB_URL", "GitHub" },
+        docker_link = { "ReaSpeechWelcomeUI.DOCKER_HUB_URL", "Docker Hub" },
+      },
+      whisper_languages = { -- WhisperLanguages
+        --oof
+      },
+      widgets = { -- Widgets, ReaSpeechWidgets
+        assert_tooltip = "missing tooltip for icon",
+        assert_missing_default = "default value not provided",
+        assert_renderer = "renderer not provided",
+        button = { -- Widgets.Button
+          assert_on_click = "handler not provided",
+        },
+        file_selector = { -- Widgets.FileSelector
+          default_title = "Save File",
+          choose_file = "Choose file",
+          input_hint = "...or type one here.",
+          jsapi_notice = {
+            "To enable file selector, ",
+            "FileSelector.JSREASCRIPT_URL",
+            "install js_ReaScriptAPI"
+          },
+        },
+      },
+    },
+    plugins = {
+      asr = { -- ASRPlugin
+        assert_app = "plugin host app is required",
+        actions = { -- ASRActions
+          assert_plugin = "plugin is required",
+          selected_tracks_label = "Process Selected Tracks",
+          selected_tracks_format = "Process %sSelected Track%s",
+          selected_items_label = "Process Selected Items",
+          selected_items_format = "Process %sSelected Item%s",
+          all_items_label = "Process All Items",
+          import_label = "Import Transcript",
+          no_media_text = "No media found to process.",
+          no_media_title = "No media",
+        },
+        controls = { -- ASRControls
+          help_model =
+          "Model to use for transcription. Larger models provide better accuracy but use more resources like disk space and memory.",
+          help_language = "Language spoken in source audio.\nSet this to 'Detect' to auto-detect the language.",
+          help_preserved_words = "Comma-separated list of words to preserve in transcript.\nExample: Jane Doe, CyberCorp",
+          help_vad = "Enable Voice Activity Detection (VAD) to filter out non-speech portions.",
+          tab_name_simple = "Simple",
+          tab_name_advanced = "Advanced",
+          assert_plugin = "plugin is required",
+          language_label = "Language",
+          translate_label_long = "Translate to English",
+          translate_label_short = "Translate",
+          hotwords_label = "Hotwords",
+          initial_prompt_label = "Hotwords",
+          vad_label_long = "Voice Activity Detection",
+          vad_label_short = "VAD",
+          model_name_label = "Model",
+        },
+      },
+      detect_language = { -- DetectLanguagePlugin
+        assert_app = "plugin host app is required",
+        undo_label = "Add languages to Track Name",
+        actions = { -- DetectLanguageActions
+          assert_plugin = "plugin is required",
+          label_button = "Label Track Languages",
+
+        },
+        controls = { -- DetectLanguageControls
+          assert_plugin = "plugin is required"
+        },
+      },
+      sample_multiple_upload = { -- SampleMultipleUploadPlugin
+        assert_app = "plugin host app is required",
+        successful_upload = "Files uploaded successfully",
+        actions = { -- SampleMultipleUploadActions
+          assert_plugin = "plugin is required",
+          upload_label = "Upload Files",
+        },
+        controls = { -- SampleMultipleUploadControls
+          assert_plugin = "plugin is required",
+          tab_name = "Multiple Uploader",
+          upload_label_1 = "Upload File 1",
+          upload_label_2 = "Upload File 2",
+        },
+      },
+      settings = { -- SettingsPlugin
+        assert_plugin = "plugin host app is required",
+        actions = { -- SettingsActions
+          assert_plugin = "plugin is required",
+        },
+        controls = { -- SettingsControls
+          tab_name = "settings",
+          assert_plugin = "plugin is required",
+          font_size_label = "Font Size",
+          logging_label = "Logging",
+          logging_basic_long = "Enable",
+          logging_basic_short = "Enable",
+          logging_debug_long = "Debug",
+          logging_debug_short = "Debug",
+        },
+      },
+    },
+  },
+}

--- a/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
+++ b/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
@@ -23,9 +23,6 @@ Strings.en = {
   -- GB = {
   --   _name = "British English",
   --   _fallback = "en",
-  --   _strings = {
-  --     color_or_colour = "colour",
-  --   },
   -- },
 
   -- IE = {
@@ -59,7 +56,6 @@ Strings.en = {
   -- },
 
   _strings = {
-    color_or_colour = "color",
     libs = {
       ctx = { -- Ctx
         label = "Application",

--- a/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
+++ b/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
@@ -373,6 +373,7 @@ Strings.en = {
           logging_basic_short = "Enable",
           logging_debug_long = "Debug",
           logging_debug_short = "Debug",
+          locale_label = "Locale",
         },
       },
     },

--- a/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
+++ b/reascripts/ReaSpeech/source/ui/localization/Strings.en.lua
@@ -10,53 +10,53 @@ Strings.en = {
   _name = "English",
   _fallback = nil,
 
-  AU = {
-    _name = "Australian English",
-    _fallback = "en",
-  },
+  -- AU = {
+  --   _name = "Australian English",
+  --   _fallback = "en",
+  -- },
 
-  CA = {
-    _name = "Canadian English",
-    _fallback = "en",
-  },
+  -- CA = {
+  --   _name = "Canadian English",
+  --   _fallback = "en",
+  -- },
 
-  GB = {
-    _name = "British English",
-    _fallback = "en",
-    _strings = {
-      color_or_colour = "colour",
-    },
-  },
+  -- GB = {
+  --   _name = "British English",
+  --   _fallback = "en",
+  --   _strings = {
+  --     color_or_colour = "colour",
+  --   },
+  -- },
 
-  IE = {
-    _name = "Irish English",
-    _fallback = "en",
-  },
+  -- IE = {
+  --   _name = "Irish English",
+  --   _fallback = "en",
+  -- },
 
-  IN = {
-    _name = "Indian English",
-    _fallback = "en",
-  },
+  -- IN = {
+  --   _name = "Indian English",
+  --   _fallback = "en",
+  -- },
 
-  NZ = {
-    _name = "New Zealand English",
-    _fallback = "en",
-  },
+  -- NZ = {
+  --   _name = "New Zealand English",
+  --   _fallback = "en",
+  -- },
 
-  SG = {
-    _name = "Singaporean English",
-    _fallback = "en",
-  },
+  -- SG = {
+  --   _name = "Singaporean English",
+  --   _fallback = "en",
+  -- },
 
-  US = {
-    _name = "American English",
-    _fallback = "en",
-  },
+  -- US = {
+  --   _name = "American English",
+  --   _fallback = "en",
+  -- },
 
-  ZA = {
-    _name = "South African English",
-    _fallback = "en",
-  },
+  -- ZA = {
+  --   _name = "South African English",
+  --   _fallback = "en",
+  -- },
 
   _strings = {
     color_or_colour = "color",

--- a/reascripts/ReaSpeech/source/ui/localization/Strings.pt.lua
+++ b/reascripts/ReaSpeech/source/ui/localization/Strings.pt.lua
@@ -8,7 +8,7 @@ Strings = Strings or {}
 
 Strings.pt = {
   _name = "Portuguese",
-  _fallback = nil,
+  _fallback = 'en',
 
   _strings = {
     plugins = {

--- a/reascripts/ReaSpeech/source/ui/localization/Strings.pt.lua
+++ b/reascripts/ReaSpeech/source/ui/localization/Strings.pt.lua
@@ -1,0 +1,43 @@
+--[[
+
+    Strings.en.lua - English localization strings
+
+]] --
+
+Strings = Strings or {}
+
+Strings.pt = {
+  _name = "Portuguese",
+  _fallback = nil,
+
+  _strings = {
+    plugins = {
+      asr = { -- ASRPlugin
+        assert_app = "O aplicativo host do plugin é necessário",
+        actions = { -- ASRActions
+          assert_plugin = "plugin é necessário",
+          selected_tracks_label = "Processar Pistas Selecionadas",
+          selected_tracks_format = "Processar %sPistas Selecionada%s",
+          selected_items_label = "Processar Artigos Selecionados",
+          selected_items_format = "Processar %sArtigos Selecionado%s",
+          all_items_label = "Processar Todos os Artigos",
+          import_label = "Importar Transcrição",
+          no_media_text = "Nenhum suporte encontrado para processar.",
+          no_media_title = "Nenhuma mídia",
+        },
+      },
+      settings = { -- SettingsPlugin
+        controls = { -- SettingsControls
+          assert_plugin = "plugin é necessário",
+          font_size_label = "Tamanho da Fonte",
+          logging_label = "Registo",
+          logging_basic_long = "Ativar",
+          logging_basic_short = "Ativar",
+          logging_debug_long = "Depurar",
+          logging_debug_short = "Depurar",
+          locale_label = "Localidade",
+        },
+      },
+    },
+  },
+}

--- a/reascripts/ReaSpeech/source/ui/localization/Strings.pt.lua
+++ b/reascripts/ReaSpeech/source/ui/localization/Strings.pt.lua
@@ -1,6 +1,6 @@
 --[[
 
-    Strings.en.lua - English localization strings
+    Strings.pt.lua - Portuguese localization strings (via Google Translate)
 
 ]] --
 

--- a/reascripts/ReaSpeech/source/ui/widgets/Button.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/Button.lua
@@ -33,8 +33,14 @@ Button.renderer = function(self)
   local disable_if = ReaUtil.disabler(ctx)
   local options = self.options
 
+  local label = options.label
+
+  if type(label) == 'function' then
+    label = label()
+  end
+
   disable_if(options.disabled, function()
-    if ImGui.Button(ctx, options.label, options.width) then
+    if ImGui.Button(ctx, label, options.width) then
       Trap(options.on_click)
     end
   end)

--- a/reascripts/ReaSpeech/source/ui/widgets/Checkbox.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/Checkbox.lua
@@ -52,6 +52,10 @@ Checkbox.renderer = function (self, column)
     label = options.label_short
   end
 
+  if type(label) == 'function' then
+    label = label()
+  end
+
   disable_if(self.options.disabled_if(), function()
     local rv, value = ImGui.Checkbox(ctx, label, self:value())
 

--- a/reascripts/ReaSpeech/tests/libs/TestTableUtils.lua
+++ b/reascripts/ReaSpeech/tests/libs/TestTableUtils.lua
@@ -25,4 +25,12 @@ function TestTableUtils:testFlatten()
   lu.assertEquals(result, {1, 2, 3, 4, 5, 6, 7, 8, 9})
 end
 
+function TestTableUtils:testShallowClone()
+  local original = {1, 2, 3}
+  local clone = table.shallow_clone(original)
+
+  lu.assertNotIs(original, clone)
+  lu.assertEquals(original, clone)
+end
+
 os.exit(lu.LuaUnit.run())

--- a/reascripts/ReaSpeech/tests/ui/TestStrings.lua
+++ b/reascripts/ReaSpeech/tests/ui/TestStrings.lua
@@ -3,6 +3,7 @@ package.path = 'source/?.lua;' .. package.path
 local lu = require('vendor/luaunit')
 
 require('tests/mock_reaper')
+require('libs/TableUtils')
 require('include/globals')
 require('ui/Strings')
 

--- a/reascripts/ReaSpeech/tests/ui/TestStrings.lua
+++ b/reascripts/ReaSpeech/tests/ui/TestStrings.lua
@@ -139,11 +139,11 @@ end
 
 function TestStrings:testAvailableLanguages()
   lu.assertItemsEquals(Strings.available_languages(), {
-    { 'en', 'English' },
-    { 'en-GB', 'British English' },
-    { 'en-US', 'American English' },
-    { 'pt', 'Portuguese' },
-    { 'pt-BR', 'Brazilian Portuguese' },
+    en = "English",
+    ['en-GB'] = "British English",
+    ['en-US'] = "American English",
+    pt = "Portuguese",
+    ['pt-BR'] = "Brazilian Portuguese",
   })
 end
 

--- a/reascripts/ReaSpeech/tests/ui/TestStrings.lua
+++ b/reascripts/ReaSpeech/tests/ui/TestStrings.lua
@@ -1,0 +1,150 @@
+package.path = 'source/?.lua;' .. package.path
+
+local lu = require('vendor/luaunit')
+
+require('tests/mock_reaper')
+require('include/globals')
+require('ui/Strings')
+
+Strings = Strings or {}
+
+Strings.en = {
+  _name = "English",
+  _fallback = nil,
+
+  GB = {
+    _name = 'British English',
+    _fallback = 'en',
+    _strings = {
+      color_or_colour = 'colour',
+      nested = {
+        isnt_it = "innit",
+      },
+      how = {
+        deep = {
+          can = {
+            we = {
+              go = "what's all this then",
+            }
+          }
+        }
+      }
+    }
+  },
+
+  US = {
+    _name = 'American English',
+    _fallback = 'en',
+    _strings = {
+    }
+  },
+
+  _strings = {
+    color_or_colour = 'color',
+    english_only = {
+      only_in_base_english = "'merica!",
+    },
+    nested = {
+      isnt_it = "isn't it",
+    },
+    how = {
+      deep = {
+        can = {
+          we = {
+            go = "very deep",
+          }
+        }
+      }
+    }
+  }
+}
+
+Strings.pt = {
+  _name = "Portuguese",
+  _fallback = 'en',
+
+  BR = {
+    _name = 'Brazilian Portuguese',
+    _fallback = 'pt',
+    _strings = {
+      nested = {
+        isnt_it = "não é!",
+      },
+      how = {
+        deep = {
+          can = {
+            we = {
+              go = "muito fundo!",
+            }
+          }
+        }
+      }
+    }
+  },
+
+  _strings = {
+    color_or_colour = 'cor',
+    nested = {
+      isnt_it = "não é",
+    },
+    how = {
+      deep = {
+        can = {
+          we = {
+            go = "muito fundo",
+          }
+        }
+      }
+    }
+  }
+}
+
+TestStrings = {}
+
+function TestStrings:testLocalize()
+  local strings = Strings.localize('en')
+  lu.assertEquals(strings.color_or_colour, 'color')
+  lu.assertEquals(strings.english_only.only_in_base_english, "'merica!")
+
+  strings = Strings.localize('en-US')
+  lu.assertEquals(strings.color_or_colour, 'color')
+  lu.assertEquals(strings.english_only.only_in_base_english, "'merica!")
+
+  strings = Strings.localize('en-GB')
+  lu.assertEquals(strings.color_or_colour, 'colour')
+  lu.assertEquals(strings.english_only.only_in_base_english, "'merica!")
+
+  strings = Strings.localize('pt-BR')
+  lu.assertEquals(strings.color_or_colour, 'cor')
+  lu.assertEquals(strings.english_only.only_in_base_english, "'merica!")
+
+  strings = Strings.localize('pt')
+  lu.assertEquals(strings.color_or_colour, 'cor')
+  lu.assertEquals(strings.english_only.only_in_base_english, "'merica!")
+end
+
+function TestStrings:testNestedString()
+  local strings = Strings.localize('en-US')
+  lu.assertEquals(strings.nested.isnt_it, "isn't it")
+  lu.assertEquals(strings.how.deep.can.we.go, "very deep")
+
+  strings = Strings.localize('en-GB')
+  lu.assertEquals(strings.nested.isnt_it, 'innit')
+  lu.assertEquals(strings.how.deep.can.we.go, "what's all this then")
+
+  strings = Strings.localize('pt-BR')
+  lu.assertEquals(strings.nested.isnt_it, "não é!")
+  lu.assertEquals(strings.how.deep.can.we.go, "muito fundo!")
+end
+
+function TestStrings:testAvailableLanguages()
+  lu.assertItemsEquals(Strings.available_languages(), {
+    { 'en', 'English' },
+    { 'en-GB', 'British English' },
+    { 'en-US', 'American English' },
+    { 'pt', 'Portuguese' },
+    { 'pt-BR', 'Brazilian Portuguese' },
+  })
+end
+
+os.exit(lu.LuaUnit.run())


### PR DESCRIPTION
this is meant to get the code-versation going around localization of the reaspeech interface. some high level notes:
- locale tags are limited to the `xx-YY` format where:
  1. `xx` = <lowercase two-character language tag, ie `en`>
  2. `yy` = <uppercase two-character region tag, ie `US`>
  - which standards to support and levels of locale tag decomposition are a bigger conversation
- string definitions are provided by setting an entry in the `Strings` table
- haven't quite worked out the best way to represent compound or link-containing strings
  - in the meantime `Strings.en` have the confusing entries represented by list tables
    - shouldn't be a problem for the moment because these strings haven't been implemented, just...noted
- a definition can supply a `_name` field to name the localization
- a definition should supply a `_fallback` field to point to where localization should look in the case of an undefined string
- i did a first pass over the source tree and copied hardcoded strings into `Strings.en` (`source/ui/localization/Strings.en.lua`), noting roughly where said strings were pulled from
- more specific localizations are built up through the chain of `_fallback`s starting at the first nil `_fallback` encountered.
  - included are some google translate-aided translations into portuguese of the controls you can see on the `Settings` tab to demonstrate locale switching
  - some widgets (those needed by the previous item) have been updated to support a `label` field function value. without this, labels were stuck in their initial value at object initialization.

it occurred to me that this might be a nice channel for the community to contribute even if they're not developers. this is true even while we're still limited by the lack of support for non-latin characters in ImGui.

demo of locale switching in the `Settings` tab:

https://github.com/user-attachments/assets/19b3eb46-3114-4fd4-9712-7c40d833ef86

