### PR TITLE
Fix startup failures due to curl error handling change

### DIFF
--- a/reascripts/ReaSpeech/source/libs/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/libs/CurlRequest.lua
@@ -220,19 +220,12 @@ function CurlRequest._init()
   end
 
   function API:execute_async(command)
-    local executor = ExecProcess.new(command)
-
-    local result = executor:background()
-    local result_code = tonumber(result:match("(-?%d+)\n"))
+    local result = ExecProcess.new(command):background()
 
     if not result then
       local err = "Unable to run curl"
       self:log(err)
       self.error_handler(err)
-    elseif result_code > 0 then
-      self.error_msg = self.curl_message(result_code)
-      self:log(self.error_msg)
-      self.error_handler(self.error_msg)
     end
 
     return self


### PR DESCRIPTION
The changes in PR #140 cause the application to fail to start on Windows and Linux. This appears to be due to the exit code returned by reaper.ExecProcess when running a background process (timeout < 0). On Windows, the exit code is 259, and on Linux, it's -1004. At least on Windows, my understanding is that this code indicates that the process is still running. If a process is running in the background, there's not really a sensible exit code to report immediately.

There's still some improvement to be made in the error message reported when the service goes down ("Couldn't open output file"), but this change at least fixes startup on Windows on Linux.