### PR TITLE
Loosen curl error check regex 

### DIFF
--- a/reascripts/ReaSpeech/source/libs/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/libs/CurlRequest.lua
@@ -327,7 +327,7 @@ function CurlRequest._init()
   end
 
   function API:check_curl_error(progress_contents)
-    local err = progress_contents:match("^curl: %((-?%d+)%).*")
+    local err = progress_contents:match("curl: %((-?%d+)%).*")
 
     if err then
       self:debug("Curl Error #" .. err)


### PR DESCRIPTION
The regex the curl error check during the sentinel check in `CurlRequest` wasn't catching this on Windows. I don't have a good grasp on why except that it a quick look at the debug output made this seem suddenly obvious. Hey, sometimes that's the way it goes. 🤷🏻‍♂️