### PR TITLE
Speed up model downloads when using whisper.cpp

### DIFF
--- a/app/whisper_cpp/core.py
+++ b/app/whisper_cpp/core.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 
+from pywhispercpp.utils import download_model
 import tqdm
 
 from ..util.audio import SAMPLE_RATE
@@ -30,7 +31,8 @@ def load_model(next_model_name: str):
         if not model:
             logger.info(Model.system_info())
 
-        model = Model(next_model_name, models_dir=model_path)
+        downloaded_model = download_model(next_model_name, model_path, 1024*1024)
+        model = Model(downloaded_model, models_dir=model_path)
 
         model_name = next_model_name
 

--- a/app/whisper_cpp/core.py
+++ b/app/whisper_cpp/core.py
@@ -15,6 +15,8 @@ from .model import Model
 logging.basicConfig(format='[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s', level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
 model_name = os.getenv("ASR_MODEL", "small")
 model_path = os.getenv("ASR_MODEL_PATH", os.path.join(os.path.expanduser("~"), ".cache", "whisper"))
 
@@ -31,7 +33,7 @@ def load_model(next_model_name: str):
         if not model:
             logger.info(Model.system_info())
 
-        downloaded_model = download_model(next_model_name, model_path, 1024*1024)
+        downloaded_model = download_model(next_model_name, model_path, DOWNLOAD_CHUNK_SIZE)
         model = Model(downloaded_model)
 
         model_name = next_model_name

--- a/app/whisper_cpp/core.py
+++ b/app/whisper_cpp/core.py
@@ -32,7 +32,7 @@ def load_model(next_model_name: str):
             logger.info(Model.system_info())
 
         downloaded_model = download_model(next_model_name, model_path, 1024*1024)
-        model = Model(downloaded_model, models_dir=model_path)
+        model = Model(downloaded_model)
 
         model_name = next_model_name
 


### PR DESCRIPTION
The default `chunk_size` used by pywhispercpp to download models is very small, resulting in slow downloads, especially on Windows. By calling `download_model` directly, we can tune this value.