### PR TITLE
Enable GPU acceleration for whisper.cpp in Docker

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -58,7 +58,7 @@ RUN git clone https://github.com/absadiki/pywhispercpp \
     && cd pywhispercpp \
     && git checkout v1.3.0 \
     && git submodule update --init \
-    && sed -i '/suppress_non_speech_tokens/d' src/main.cpp \
+    && sed -i 's/suppress_non_speech_tokens/suppress_nst/g' src/main.cpp pywhispercpp/constants.py \
     && cd whisper.cpp \
     && git checkout v1.7.4 \
     && cd .. \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,9 +1,5 @@
 FROM swaggerapi/swagger-ui:v4.18.2 AS swagger-ui
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
-
-ARG SERVICE_USER=service
-ARG SERVICE_UID=1001
-ARG SERVICE_GID=1001
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04 AS builder
 
 ENV PYTHON_VERSION=3.10
 ENV POETRY_VENV=/app/.venv
@@ -15,41 +11,18 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     python${PYTHON_VERSION}-dev \
     python${PYTHON_VERSION}-venv \
     python3-pip \
-    lua5.3 \
-    lua5.4 \
-    lua-check \
-    fswatch \
-    make \
     build-essential \
     git \
-    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
-    ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
-    ln -s -f /usr/bin/pip3 /usr/bin/pip
-
-RUN groupadd -g $SERVICE_GID $SERVICE_USER \
-    && useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER \
-    || echo "Error creating service account: $?"
-
-COPY --chown=$SERVICE_UID:$SERVICE_GID . /app
-COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui.css /app/swagger-ui-assets/swagger-ui.css
-COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js /app/swagger-ui-assets/swagger-ui-bundle.js
-RUN chown $SERVICE_UID:$SERVICE_GID /app
-
-USER $SERVICE_UID:$SERVICE_GID
-
+COPY . /app
 WORKDIR /app
 
-RUN python3 -m venv $POETRY_VENV \
+RUN /usr/bin/python${PYTHON_VERSION} -m venv $POETRY_VENV \
     && $POETRY_VENV/bin/pip install -U pip setuptools \
     && $POETRY_VENV/bin/pip install poetry==1.6.1
 
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${POETRY_VENV}/lib/python${PYTHON_VERSION}/site-packages"
-
-COPY --chown=$SERVICE_UID:$SERVICE_GID poetry.lock pyproject.toml ./
 
 RUN poetry config virtualenvs.in-project true
 RUN poetry install && rm -rf /app/.cache/pypoetry
@@ -63,6 +36,49 @@ RUN git clone https://github.com/absadiki/pywhispercpp \
     && git checkout v1.7.4 \
     && cd .. \
     && GGML_CUDA=1 $POETRY_VENV/bin/pip install -e .
+
+FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+
+ARG SERVICE_USER=service
+ARG SERVICE_UID=1001
+ARG SERVICE_GID=1001
+
+ENV PYTHON_VERSION=3.10
+ENV POETRY_VENV=/app/.venv
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -qq update \
+    && apt-get -qq install --no-install-recommends \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-venv \
+    python3-pip \
+    lua5.3 \
+    lua5.4 \
+    lua-check \
+    fswatch \
+    make \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 && \
+    ln -s -f /usr/bin/python${PYTHON_VERSION} /usr/bin/python && \
+    ln -s -f /usr/bin/pip3 /usr/bin/pip
+
+RUN groupadd -g $SERVICE_GID $SERVICE_USER \
+    && useradd -u $SERVICE_UID -g $SERVICE_GID -d /app -s /usr/sbin/nologin $SERVICE_USER \
+    || echo "Error creating service account: $?"
+
+COPY --chown=$SERVICE_UID:$SERVICE_GID --from=builder /app /app
+COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui.css /app/swagger-ui-assets/swagger-ui.css
+COPY --chown=$SERVICE_UID:$SERVICE_GID --from=swagger-ui /usr/share/nginx/html/swagger-ui-bundle.js /app/swagger-ui-assets/swagger-ui-bundle.js
+RUN chown $SERVICE_UID:$SERVICE_GID /app
+
+USER $SERVICE_UID:$SERVICE_GID
+
+ENV PATH="${PATH}:${POETRY_VENV}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${POETRY_VENV}/lib/python${PYTHON_VERSION}/site-packages"
+
+WORKDIR /app
 
 RUN $POETRY_VENV/bin/pip install --no-cache-dir torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -54,9 +54,17 @@ COPY --chown=$SERVICE_UID:$SERVICE_GID poetry.lock pyproject.toml ./
 RUN poetry config virtualenvs.in-project true
 RUN poetry install && rm -rf /app/.cache/pypoetry
 
-RUN $POETRY_VENV/bin/pip install --no-cache-dir torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch
+RUN git clone https://github.com/absadiki/pywhispercpp \
+    && cd pywhispercpp \
+    && git checkout v1.3.0 \
+    && git submodule update --init \
+    && sed -i '/suppress_non_speech_tokens/d' src/main.cpp \
+    && cd whisper.cpp \
+    && git checkout master \
+    && cd .. \
+    && GGML_CUDA=1 $POETRY_VENV/bin/pip install -e .
 
-RUN GGML_CUDA=1 $POETRY_VENV/bin/pip install --no-cache-dir git+https://github.com/absadiki/pywhispercpp@v1.3.0
+RUN $POETRY_VENV/bin/pip install --no-cache-dir torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch
 
 WORKDIR /app/reascripts/ReaSpeech
 RUN make publish

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -60,7 +60,7 @@ RUN git clone https://github.com/absadiki/pywhispercpp \
     && git submodule update --init \
     && sed -i '/suppress_non_speech_tokens/d' src/main.cpp \
     && cd whisper.cpp \
-    && git checkout master \
+    && git checkout v1.7.4 \
     && cd .. \
     && GGML_CUDA=1 $POETRY_VENV/bin/pip install -e .
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -12,6 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get -qq update \
     && apt-get -qq install --no-install-recommends \
     python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev \
     python${PYTHON_VERSION}-venv \
     python3-pip \
     lua5.3 \
@@ -20,7 +21,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     fswatch \
     make \
     build-essential \
-    python3.10-dev \
     git \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,5 +1,5 @@
 FROM swaggerapi/swagger-ui:v4.18.2 AS swagger-ui
-FROM nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
 
 ARG SERVICE_USER=service
 ARG SERVICE_UID=1001
@@ -19,6 +19,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     lua-check \
     fswatch \
     make \
+    build-essential \
+    python3.10-dev \
+    git \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
@@ -44,14 +47,16 @@ RUN python3 -m venv $POETRY_VENV \
     && $POETRY_VENV/bin/pip install poetry==1.6.1
 
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${POETRY_VENV}/lib/python${PYTHON_VERSION}/site-packages"
 
 COPY --chown=$SERVICE_UID:$SERVICE_GID poetry.lock pyproject.toml ./
 
 RUN poetry config virtualenvs.in-project true
-RUN poetry install --no-root
-
 RUN poetry install && rm -rf /app/.cache/pypoetry
+
 RUN $POETRY_VENV/bin/pip install --no-cache-dir torch==1.13.1+cu117 -f https://download.pytorch.org/whl/torch
+
+RUN GGML_CUDA=1 $POETRY_VENV/bin/pip install --no-cache-dir git+https://github.com/absadiki/pywhispercpp@v1.3.0
 
 WORKDIR /app/reascripts/ReaSpeech
 RUN make publish


### PR DESCRIPTION
This change updates Dockerfile.gpu to build pywhispercpp with CUDA support. This requires building whisper.cpp with the CUDA development toolkit, which is quite large (about 6GB). To avoid increasing the size of the reaspeech-gpu image, Dockerfile.gpu has been reorganized as a multi-stage build, using the "devel" CUDA image to build, and the "runtime" image as the basis for the final image. Fixes #148

In order to get CUDA support to work, it was necessary to use a more recent version of whisper.cpp than the one the latest version of pywhispercpp targets. This was done by using a git checkout and updating the whisper.cpp submodule to a specific version tag. Due to a breaking change (a renamed whisper.cpp setting, "suppress_non_speech_tokens" became "suppress_nst"), a minor search-and-replace was necessary to get it to compile. Then, pip can be used to install the pywhispercpp package from a local directory.

It was also necessary to append the Python site-packages directory to LD_LIBRARY_PATH so that pywhispercpp could find the libwhisper.so library.

With these changes, and ASR_ENGINE=whisper_cpp, ReaSpeech can do GPU-accelerated transcription on Windows in a Docker container, and the performance is competitive with faster-whisper.