### PR TITLE
Plugin-defined Top-level Drop Zones

### DIFF
--- a/reascripts/ReaSpeech/source/libs/Plugin.lua
+++ b/reascripts/ReaSpeech/source/libs/Plugin.lua
@@ -31,6 +31,14 @@ function Plugin(definition)
     return self._controls:new_tab_menu()
   end
 
+  function plugin:drop_zones(files)
+    if not self._controls then return {} end
+
+    if not self._controls.drop_zones then return {} end
+
+    return self._controls:drop_zones(files)
+  end
+
   function plugin:actions()
     if not self._actions then return {} end
 

--- a/reascripts/ReaSpeech/source/main/Transcript.lua
+++ b/reascripts/ReaSpeech/source/main/Transcript.lua
@@ -103,6 +103,20 @@ function Transcript:has_words()
   return false
 end
 
+function Transcript:segment_iterator()
+  local segments = self.data
+  local segment_count = #segments
+  local segment_i = 1
+
+  return function ()
+    if segment_i <= segment_count then
+      local segment = segments[segment_i]
+      segment_i = segment_i + 1
+      return segment
+    end
+  end
+end
+
 function Transcript:iterator(use_words)
   local segments = self.data
   local segment_count = #segments
@@ -124,6 +138,7 @@ function Transcript:iterator(use_words)
           text = segment:get('text'),
           item = segment.item,
           take = segment.take,
+          words = segment.words,
         }
       end
 

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechPlugins.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechPlugins.lua
@@ -42,6 +42,18 @@ function ReaSpeechPlugins:get_plugin(key)
   end
 end
 
+function ReaSpeechPlugins:drop_zones(files)
+  local drop_zones = {}
+
+  for _, plugin in ipairs(self._plugins) do
+    for _, drop_zone in ipairs(plugin:drop_zones(files)) do
+      table.insert(drop_zones, drop_zone)
+    end
+  end
+
+  return drop_zones
+end
+
 function ReaSpeechPlugins:add_plugin(plugin)
   local new_plugin
   if type(plugin) == 'function' then

--- a/reascripts/ReaSpeech/source/ui/widgets/TabBar.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/TabBar.lua
@@ -40,12 +40,16 @@ TabBar.renderer = function (self)
       tabs = tabs()
     end
 
-    for _, tab in pairs(tabs) do
-      if tab.on_click then
-        TabBar.render_tab_button(self, tab)
-      else
-        TabBar.render_tab_item(self, tab, current_value)
-      end
+    for i, tab in ipairs(tabs) do
+      ImGui.PushID(ctx, 'tab- ' .. i)
+      Trap(function()
+        if tab.on_click then
+          TabBar.render_tab_button(self, tab)
+        else
+          TabBar.render_tab_item(self, tab, current_value)
+        end
+        end)
+      ImGui.PopID(ctx)
     end
     ImGui.EndTabBar(ctx)
   end

--- a/reascripts/ReaSpeech/source/ui/widgets/TabBar.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/TabBar.lua
@@ -48,7 +48,7 @@ TabBar.renderer = function (self)
         else
           TabBar.render_tab_item(self, tab, current_value)
         end
-        end)
+      end)
       ImGui.PopID(ctx)
     end
     ImGui.EndTabBar(ctx)


### PR DESCRIPTION
Plugins can now implement `drop_zones(file_list)`:
  - implementations should return a list of candidate drop zones based on the provided `file_list` argument
  - structure is `{ render: <drop zone rendering function>, on_drop: <actual drop handler> }`

`TranscriptUI` now offers a loader (that can load multiple files) and (if more than one file is dragged in) a combiner that will create a merged transcript from all dragged-in files.

https://github.com/user-attachments/assets/543fa69d-ccde-4319-8865-ca76dff68cc1

