### PR TITLE
Apply "quick import" to "+" tab and allow multiple file selection

### DIFF
--- a/reascripts/ReaSpeech/source/ui/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ui/ASRActions.lua
@@ -106,40 +106,10 @@ function ASRActions:import_button()
 
   self._import_button = Widgets.Button.new({
     label = "Import Transcript",
-    on_click = self._import_click
+    on_click = TranscriptImporter.quick_import
   })
 
   return self._import_button
-end
-
-ASRActions._import_click = function()
-  local filenames = Widgets.FileSelector.simple_open(
-    'Import Transcript',
-    { json = 'JSON Files' }
-  )
-
-  local importer = app.plugins(ASRPlugin:key()):importer()
-
-  if #filenames < 1 then
-    importer:present()
-    return
-  end
-
-  -- only considering one selection for the moment
-  local selection = filenames[1]
-
-  local transcript, err = importer:import(selection)
-
-  if not transcript or err then
-    importer:present()
-  else
-    local plugin = TranscriptUI.new {
-      app = app,
-      transcript = transcript,
-      _transcript_saved = true
-    }
-    app.plugins:add_plugin(plugin)
-  end
 end
 
 function ASRActions.pluralizer(count, suffix)

--- a/reascripts/ReaSpeech/source/ui/ASRActions.lua
+++ b/reascripts/ReaSpeech/source/ui/ASRActions.lua
@@ -106,7 +106,7 @@ function ASRActions:import_button()
 
   self._import_button = Widgets.Button.new({
     label = "Import Transcript",
-    on_click = TranscriptImporter.quick_import
+    on_click = TranscriptImporter:quick_import()
   })
 
   return self._import_button

--- a/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
@@ -130,3 +130,33 @@ function TranscriptImporter:import(filepath)
 
   return transcript
 end
+
+TranscriptImporter.quick_import = function()
+  local filenames = Widgets.FileSelector.simple_open(
+    'Import Transcript',
+    { json = 'JSON Files' }
+  )
+
+  local importer = app.plugins(ASRPlugin:key()):importer()
+
+  if #filenames < 1 then
+    importer:present()
+    return
+  end
+
+  -- only considering one selection for the moment
+  local selection = filenames[1]
+
+  local transcript, err = importer:import(selection)
+
+  if not transcript or err then
+    importer:present()
+  else
+    local plugin = TranscriptUI.new {
+      app = app,
+      transcript = transcript,
+      _transcript_saved = true
+    }
+    app.plugins:add_plugin(plugin)
+  end
+end

--- a/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
@@ -131,32 +131,63 @@ function TranscriptImporter:import(filepath)
   return transcript
 end
 
-TranscriptImporter.quick_import = function()
-  local filenames = Widgets.FileSelector.simple_open(
-    'Import Transcript',
-    { json = 'JSON Files' }
-  )
+function TranscriptImporter:quick_import()
+  return function()
+    local filenames = Widgets.FileSelector.simple_open(
+      'Import Transcript',
+      { json = 'JSON Files' },
+      { allow_multiple = true }
+    )
 
-  local importer = app.plugins(ASRPlugin:key()):importer()
+    if #filenames < 1 then
+      local importer = app.plugins(ASRPlugin:key()):importer()
+      importer:present()
+      return
+    end
 
-  if #filenames < 1 then
-    importer:present()
-    return
-  end
+    local valid_filenames = {}
+    for _, filename in ipairs(filenames) do
+      if filename and filename ~= '' then
+        table.insert(valid_filenames, filename)
+      end
+    end
 
-  -- only considering one selection for the moment
-  local selection = filenames[1]
+    local load_errors = {}
 
-  local transcript, err = importer:import(selection)
+    for _, filename in ipairs(valid_filenames) do
+      local can_import, msg = self:can_import(filename)
 
-  if not transcript or err then
-    importer:present()
-  else
-    local plugin = TranscriptUI.new {
-      app = app,
-      transcript = transcript,
-      _transcript_saved = true
-    }
-    app.plugins:add_plugin(plugin)
+      if not can_import then
+        table.insert(load_errors, {filename, msg})
+      else
+        local transcript, err = self:import(filename)
+
+        if not transcript or err then
+          table.insert(load_errors, {filename, err})
+        else
+          local plugin = TranscriptUI.new {
+            app = app,
+            transcript = transcript,
+            _transcript_saved = true
+          }
+          app.plugins:add_plugin(plugin)
+        end
+      end
+    end
+
+    if #load_errors > 0 then
+      local title = 'Import complete, but...'
+      local msg = 'Some selected files were not loaded:\n\n%s'
+
+      local messages = {}
+
+      for _, err in ipairs(load_errors) do
+        table.insert(messages, PathUtil.get_filename(err[1]) .. ': ' .. err[2])
+      end
+
+      local file_messages = table.concat(messages, '\n')
+
+      app.alert_popup:show(title, msg:format(file_messages))
+    end
   end
 end

--- a/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
@@ -135,7 +135,7 @@ function TranscriptUI:new_tab_menu()
 
   return {
     { label = "Load Transcript",
-      on_click = TranscriptImporter.quick_import
+      on_click = TranscriptImporter:quick_import()
     },
   }
 end

--- a/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
@@ -135,9 +135,7 @@ function TranscriptUI:new_tab_menu()
 
   return {
     { label = "Load Transcript",
-      on_click = function()
-        self.app.plugins(ASRPlugin:key()):importer():open()
-      end
+      on_click = TranscriptImporter.quick_import
     },
   }
 end


### PR DESCRIPTION
this applies "quick import" behavior (skipping the importer dialog if file selections are made) consistently between the "Import Transcript" button under Speech Recognition and the "+" tab's "Load Transcript" menu option. 

while i was in there i went ahead and made it handle multiple files similarly to drag/drop loading.

if there are problems with the files selected for loading, an alert will inform the user per-file what the error was. files without loading problems are loaded, and there's no explicit "success" message or indication beyond new transcript tabs showing up.

https://github.com/user-attachments/assets/b990a12b-45c9-4349-a006-af1055735e88

