### PR TITLE
Retain extra project references when processing a source file

### DIFF
--- a/reascripts/ReaSpeech/source/main/TranscriptSegment.lua
+++ b/reascripts/ReaSpeech/source/main/TranscriptSegment.lua
@@ -221,6 +221,18 @@ function TranscriptSegment:navigate(word_index, autoplay)
   end
 end
 
+function TranscriptSegment:timeline_start_time()
+  return reaper.GetMediaItemInfo_Value(self.item, 'D_POSITION')
+    + self.start
+    - reaper.GetMediaItemTakeInfo_Value(self.take, 'D_STARTOFFS')
+end
+
+function TranscriptSegment:timeline_end_time()
+  return reaper.GetMediaItemInfo_Value(self.item, 'D_POSITION')
+    + self.end_
+    - reaper.GetMediaItemTakeInfo_Value(self.take, 'D_STARTOFFS')
+end
+
 function TranscriptSegment:_navigate_to_media_item(item)
   reaper.SelectAllMediaItems(0, false)
   reaper.SetMediaItemSelected(item, true)

--- a/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
@@ -503,8 +503,10 @@ function TranscriptUI:render_table_cell(segment, column)
     self:render_text(segment, column)
   elseif column == "score" then
     self:render_score(segment:get(column, 0.0))
-  elseif column == "start" or column == "end" then
-    ImGui.Text(ctx, reaper.format_timestr(segment:get(column, 0.0), ''))
+  elseif column == 'start' then
+    ImGui.Text(ctx, reaper.format_timestr(segment:timeline_start_time(), ''))
+  elseif column == 'end' then
+    ImGui.Text(ctx, reaper.format_timestr(segment:timeline_end_time(), ''))
   else
     local value = segment:get(column)
     if type(value) == 'table' then


### PR DESCRIPTION
currently, if you ask ReaSpeech to process a collection of tracks/items that sees the same source file more than once, only one of those media item/take references will be retained and added as a transcript segment.

this change retains those extra references, and for each one will add the found segments for a given source file to the transcript. yes, this means that you can have the same text show up multiple times in a transcript. no, i don't think that's weird, it's _your_ weird project, friend!

this also changes the start/end columns in the transcript table to reflect the segment's start/end relative to the full project timeline.

from here i'm picturing what the ux might look like for resolving overlap conflicts. 🤔

https://github.com/user-attachments/assets/d4ea3d1d-fbd5-4a25-9bee-4405b4540d20

