### PR TITLE
Fix job countdown in ASRPlugin response handler

### DIFF
--- a/reascripts/ReaSpeech/source/ui/ASRPlugin.lua
+++ b/reascripts/ReaSpeech/source/ui/ASRPlugin.lua
@@ -48,6 +48,15 @@ function ASRPlugin:asr(jobs)
     data.initial_prompt = controls_data.initial_prompt
   end
 
+  local job_count = 0
+  local seen = {}
+  for _, job in pairs(jobs) do
+    if not seen[job.path] then
+      seen[job.path] = true
+      job_count = job_count + 1
+    end
+  end
+
   local request = {
     data = data,
     file_uploads = {
@@ -55,7 +64,7 @@ function ASRPlugin:asr(jobs)
     },
     jobs = jobs,
     endpoint = self.ENDPOINT,
-    callback = self:handle_response(#jobs)
+    callback = self:handle_response(job_count)
   }
 
   self.app:submit_request(request)


### PR DESCRIPTION
this chunk of code wasn't accounting for the deduplication of files between initial job list creation. now doing a quick pass looking for unique filenames to come up with an actual expected number of times that the response handler should be invoked for the whole request.