### PR TITLE
Apple Silicon GPU instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ ReaSpeech is a ReaScript frontend that will take your project's media items and 
 
 Please see our [Apple Silicon GPU instructions](docs/no-docker.md#apple-silicon-gpu)
 
+---
+
 For more detailed instructions, see [Docker Usage](docs/docker.md)
 
 # Documentation

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ ReaSpeech is a ReaScript frontend that will take your project's media items and 
 
     docker run -d -p 9000:9000 --name reaspeech techaudiodoc/reaspeech:latest
 
-### GPU (currently Windows/NVIDIA only)
+### GPU: Windows/NVIDIA
 
     docker run -d --gpus all -p 9000:9000 --name reaspeech-gpu techaudiodoc/reaspeech:latest-gpu
+
+### GPU: Apple Silicon
+
+Please see our [Apple Silicon GPU instructions](docs/no-docker.md#apple-silicon-gpu)
 
 For more detailed instructions, see [Docker Usage](docs/docker.md)
 

--- a/docs/no-docker.md
+++ b/docs/no-docker.md
@@ -1,4 +1,4 @@
-### Running Outside of Docker
+# Running Outside of Docker
 
 ReaSpeech can be run without using Docker. You will probably need Python 3.10. Other versions of Python may work, but this is the version we currently standardize on. Some of ReaSpeech's dependencies can be sensitive to the Python version.
 
@@ -29,38 +29,57 @@ poetry run python3.10 gunicorn --bind 0.0.0.0:9000 --workers 1 --timeout 0 app.w
 
 See the source code to app/run.py for details. This is the same script that the Docker container runs when it starts.
 
-### Apple Silicon GPU
+## Apple Silicon GPU
 
-The whisper.cpp engine can do GPU-accelerated transcription on Apple Silicon (M1-M4, etc.) GPUs. Support for these GPUs requires running ReaSpeech outside of Docker. The following instructions should help you get started:
-
-```
-Install Xcode Command Line Tools (if necessary)
-xcode-select --install
-
-Install Homebrew (if necessary)
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-Install Lua and Python
-brew install lua@5.4 python@3.10 ffmpeg
-
-Install Poetry
-curl -sSL https://install.python-poetry.org | python3.10 -
-
-Clone the repo
-git clone https://github.com/TeamAudio/reaspeech.git
-
-Install the Python dependencies
-cd reaspeech
-poetry install
-
-Run the ReaSpeech service
-ASR_ENGINE=whisper_cpp poetry run python3.10 app/run.py --build-reascripts
-```
+The whisper.cpp engine can do GPU-accelerated transcription on Apple Silicon (M1-M4, etc.) processors, which can significantly speed up transcriptions times. GPU support for these processors requires running ReaSpeech outside of Docker.
 
 Please note that there are a few limitations to running the whisper.cpp ASR engine:
 
 1. whisper.cpp timestamps are less accurate than openai-whisper or faster-whisper
 2. Word-level timestamps, in particular, can be progressively less accurate within a segment
 3. Not all features of the openai-whisper or faster-whisper engines are supported
+4. You will need to set up a development environment to run ReaSpeech outside of Docker
 
-That said, enabling GPU support can significantly speed up transcription times. If you have an Apple Silicon GPU, we recommend giving it a try.
+That said, the performance improvement with GPU support can make this approach worthwhile. If you have an Apple Silicon-based machine, we recommend giving it a try.
+
+### Installation Instructions
+
+The following steps should help you get started running ReaSpeech locally on your Apple Silicon machine.
+
+Install Xcode Command Line Tools. This will install commands like git and make. You can skip this step if you already have these tools installed.
+```bash
+xcode-select --install
+```
+
+Install Homebrew. This will help you install Lua, Python, and other dependencies. You can skip this step if you already have Homebrew, or if you prefer to install these dependencies manually.
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Install Lua and Python. Please note the specific versions of Lua and Python that ReaSpeech requires.
+```bash
+brew install lua@5.4 python@3.10 ffmpeg
+```
+
+Install Poetry. This will help you manage the Python dependencies that ReaSpeech requires.
+```bash
+curl -sSL https://install.python-poetry.org | python3.10 -
+```
+
+Clone the ReaSpeech repository. This will give you the source code for ReaSpeech.
+```bash
+git clone https://github.com/TeamAudio/reaspeech.git
+```
+
+Install the Python dependencies. This will install the libraries that ReaSpeech requires.
+```bash
+cd reaspeech
+poetry install
+```
+
+Run the ReaSpeech service.
+```bash
+ASR_ENGINE=whisper_cpp poetry run python3.10 app/run.py --build-reascripts
+```
+
+Once you have done this, you should be able to access ReaSpeech at http://localhost:9000.

--- a/docs/no-docker.md
+++ b/docs/no-docker.md
@@ -31,7 +31,7 @@ See the source code to app/run.py for details. This is the same script that the 
 
 ## Apple Silicon GPU
 
-The whisper.cpp engine can do GPU-accelerated transcription on Apple Silicon (M1-M4, etc.) processors, which can significantly speed up transcriptions times. GPU support for these processors requires running ReaSpeech outside of Docker.
+The whisper.cpp engine can do GPU-accelerated transcription on Apple Silicon (M1-M4, etc.) processors, which can significantly speed up transcription time. GPU support for these processors requires running ReaSpeech outside of Docker.
 
 Please note that there are a few limitations to running the whisper.cpp ASR engine:
 

--- a/docs/no-docker.md
+++ b/docs/no-docker.md
@@ -28,3 +28,39 @@ poetry run python3.10 gunicorn --bind 0.0.0.0:9000 --workers 1 --timeout 0 app.w
 ```
 
 See the source code to app/run.py for details. This is the same script that the Docker container runs when it starts.
+
+### Apple Silicon GPU
+
+The whisper.cpp engine can do GPU-accelerated transcription on Apple Silicon (M1-M4, etc.) GPUs. Support for these GPUs requires running ReaSpeech outside of Docker. The following instructions should help you get started:
+
+```
+Install Xcode Command Line Tools (if necessary)
+xcode-select --install
+
+Install Homebrew (if necessary)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+Install Lua and Python
+brew install lua@5.4 python@3.10 ffmpeg
+
+Install Poetry
+curl -sSL https://install.python-poetry.org | python3.10 -
+
+Clone the repo
+git clone https://github.com/TeamAudio/reaspeech.git
+
+Install the Python dependencies
+cd reaspeech
+poetry install
+
+Run the ReaSpeech service
+ASR_ENGINE=whisper_cpp poetry run python3.10 app/run.py --build-reascripts
+```
+
+Please note that there are a few limitations to running the whisper.cpp ASR engine:
+
+1. whisper.cpp timestamps are less accurate than openai-whisper or faster-whisper
+2. Word-level timestamps, in particular, can be progressively less accurate within a segment
+3. Not all features of the openai-whisper or faster-whisper engines are supported
+
+That said, enabling GPU support can significantly speed up transcription times. If you have an Apple Silicon GPU, we recommend giving it a try.

--- a/docs/no-docker.md
+++ b/docs/no-docker.md
@@ -51,17 +51,17 @@ Install Xcode Command Line Tools. This will install commands like git and make. 
 xcode-select --install
 ```
 
-Install Homebrew. This will help you install Lua, Python, and other dependencies. You can skip this step if you already have Homebrew, or if you prefer to install these dependencies manually.
+Install [Homebrew](https://brew.sh). This will help you install Lua, Python, and other dependencies. You can skip this step if you already have Homebrew, or if you prefer to install these dependencies manually.
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-Install Lua and Python. Please note the specific versions of Lua and Python that ReaSpeech requires.
+Install Lua, Python, and FFmpeg. Please note the specific versions of Lua and Python that ReaSpeech requires.
 ```bash
 brew install lua@5.4 python@3.10 ffmpeg
 ```
 
-Install Poetry. This will help you manage the Python dependencies that ReaSpeech requires.
+Install [Poetry](https://python-poetry.org). This will help you manage the Python dependencies that ReaSpeech requires.
 ```bash
 curl -sSL https://install.python-poetry.org | python3.10 -
 ```


### PR DESCRIPTION
This change adds instructions for running ReaSpeech via the command line on OSX, using the whisper.cpp engine, which allows users to get GPU acceleration on Apple Silicon-based Macs. To get GPU support on Mac, one has to run ReaSpeech outside of Docker, which requires a basic development environment (python3.10, luac4.5, make, etc.) to build and run the application.
