### PR TITLE
Move logging Storage initialization to Logging module

### DIFF
--- a/reascripts/ReaSpeech/source/libs/Logging.lua
+++ b/reascripts/ReaSpeech/source/libs/Logging.lua
@@ -17,18 +17,13 @@ Logging = setmetatable({}, {
 })
 
 Logging._init = function()
-  local storage = Storage.ExtState.make {
-    section = 'ReaSpeech.Logging',
-    persist = true,
-  }
-
   local API = {}
   API = {
     LOG_LEVEL_LOG = false,
     LOG_LEVEL_DEBUG = true,
 
-    show_logs = storage:boolean('show_logs', false),
-    show_debug_logs = storage:boolean('show_debug_logs', false),
+    show_logs = Storage.memory(false),
+    show_debug_logs = Storage.memory(false),
 
     logs = {},
 

--- a/reascripts/ReaSpeech/source/libs/Logging.lua
+++ b/reascripts/ReaSpeech/source/libs/Logging.lua
@@ -17,13 +17,18 @@ Logging = setmetatable({}, {
 })
 
 Logging._init = function()
+  local storage = Storage.ExtState.make {
+    section = 'ReaSpeech.Logging',
+    persist = true,
+  }
+
   local API = {}
   API = {
     LOG_LEVEL_LOG = false,
     LOG_LEVEL_DEBUG = true,
 
-    show_logs = Storage.memory(false),
-    show_debug_logs = Storage.memory(false),
+    show_logs = storage:boolean('show_logs', false),
+    show_debug_logs = storage:boolean('show_debug_logs', false),
 
     logs = {},
 

--- a/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
@@ -13,6 +13,8 @@ function ReaSpeechMain:main()
   if not self:check_imgui() then return end
   reaper.atexit(function () self:on_exit() end)
 
+  self:init_logging()
+
   self:init_ctx()
   ctx = Ctx()
 
@@ -54,6 +56,16 @@ function ReaSpeechMain:init_ctx()
   Ctx.on_create = function (ctx)
     Fonts:init(ctx)
   end
+end
+
+function ReaSpeechMain:init_logging()
+  local storage = Storage.ExtState.make {
+    section = 'ReaSpeech.Logging',
+    persist = true,
+  }
+
+  Logging().show_logs = storage:boolean('show_logs', false)
+  Logging().show_debug_logs = storage:boolean('show_debug_logs', false)
 end
 
 function ReaSpeechMain:on_exit()

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechUI.lua
@@ -53,7 +53,7 @@ function ReaSpeechUI:init()
     -- DetectLanguagePlugin,
     -- SampleMultipleUploadPlugin,
     TranscriptUI.plugin(),
-   })
+  })
 
   self.controls_ui = ReaSpeechControlsUI.new({
     plugins = self.plugins,

--- a/reascripts/ReaSpeech/source/ui/SettingsControls.lua
+++ b/reascripts/ReaSpeech/source/ui/SettingsControls.lua
@@ -58,14 +58,6 @@ function SettingsControls:init_layout()
 end
 
 function SettingsControls:init_logging()
-  local storage = Storage.ExtState.make {
-    section = 'ReaSpeech.Logging',
-    persist = true,
-  }
-
-  Logging().show_logs = storage:boolean('show_logs', false)
-  Logging().show_debug_logs = storage:boolean('show_debug_logs', false)
-
   self.log_enable = Widgets.Checkbox.new {
     state = Logging().show_logs,
     label_long = 'Enable',


### PR DESCRIPTION
With the Settings plugin no longer initialized at app startup, the saved logging (log/debug) preferences weren't getting loaded. This ~swaps~ moves the `Storage` initialization for `Logging` over to ~that module~ `ReaSpeechMain` and has `SettingsControls` reference ~those relocated storage cells~ `Logging`'s `show_logs/show_debug_logs` in its checkbox widgets.