### PR TITLE
Call Ctx everywhere

### DIFF
--- a/reascripts/ReaSpeech/source/libs/ToolWindow.lua
+++ b/reascripts/ReaSpeech/source/libs/ToolWindow.lua
@@ -99,12 +99,12 @@ ToolWindow.modal = function(o, config)
   config.is_modal = true
 
   ToolWindow._wrap_method_0_args(o, 'open', function()
-    ImGui.OpenPopup(ctx, o._tool_window.title)
+    ImGui.OpenPopup(Ctx(), o._tool_window.title)
     return true
   end)
 
   ToolWindow._wrap_method_0_args(o, 'close', function()
-    ImGui.CloseCurrentPopup(ctx)
+    ImGui.CloseCurrentPopup(Ctx())
     return true
   end)
 
@@ -263,13 +263,13 @@ function ToolWindow.render(o)
   end
 
   local f = function()
-    state.theme:wrap(ctx, function()
+    state.theme:wrap(Ctx(), function()
       ToolWindow._render_window(o)
     end, Trap)
   end
 
   if state.font then
-    Fonts.wrap(ctx, Fonts.main, f, Trap)
+    Fonts.wrap(Ctx(), Fonts.main, f, Trap)
   else
     f()
   end
@@ -279,22 +279,22 @@ function ToolWindow._render_window(o)
   local state = o._tool_window
 
   if state.position == ToolWindow.POSITION_CENTER then
-    local center = {ImGui.Viewport_GetCenter(ImGui.GetWindowViewport(ctx))}
-    ImGui.SetNextWindowPos(ctx, center[1], center[2], ImGui.Cond_Appearing(), 0.5, 0.5)
+    local center = {ImGui.Viewport_GetCenter(ImGui.GetWindowViewport(Ctx()))}
+    ImGui.SetNextWindowPos(Ctx(), center[1], center[2], ImGui.Cond_Appearing(), 0.5, 0.5)
   elseif type(state.position) == 'table' and #state.position == 2 then
     local position = state.position
-    ImGui.SetNextWindowPos(ctx, position[1], position[2], ImGui.Cond_Appearing())
+    ImGui.SetNextWindowPos(Ctx(), position[1], position[2], ImGui.Cond_Appearing())
   end
 
-  ImGui.SetNextWindowSize(ctx, state.width, state.height, ImGui.Cond_FirstUseEver())
-  local visible, open = state.begin_f(ctx, state.title, true, state.window_flags)
+  ImGui.SetNextWindowSize(Ctx(), state.width, state.height, ImGui.Cond_FirstUseEver())
+  local visible, open = state.begin_f(Ctx(), state.title, true, state.window_flags)
   if visible then
     Trap(function ()
       if o.render_content then
         o:render_content()
       end
     end)
-    state.end_f(ctx)
+    state.end_f(Ctx())
   else
     -- Checking for "not NoCollapse" here accounts for the main window
     -- that can be minimized and expanded.
@@ -312,7 +312,7 @@ function ToolWindow._render_window(o)
 end
 
 function ToolWindow.render_separator(_o)
-  ImGui.Dummy(ctx, 0, 0)
-  ImGui.Separator(ctx)
-  ImGui.Dummy(ctx, 0, 0)
+  ImGui.Dummy(Ctx(), 0, 0)
+  ImGui.Separator(Ctx())
+  ImGui.Dummy(Ctx(), 0, 0)
 end

--- a/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
@@ -4,7 +4,6 @@
 
 ]]--
 
-ctx = nil
 app = nil
 
 ReaSpeechMain = {}
@@ -14,9 +13,7 @@ function ReaSpeechMain:main()
   reaper.atexit(function () self:on_exit() end)
 
   self:init_logging()
-
   self:init_ctx()
-  ctx = Ctx()
 
   Theme:init()
   app = ReaSpeechUI.new()
@@ -28,8 +25,7 @@ end
 function ReaSpeechMain:loop()
   return function()
     if app:presenting() or app:is_open() then
-      ctx = Ctx()
-      Fonts:check(ctx)
+      Fonts:check(Ctx())
       Trap(function() app:react() end)
       reaper.defer(self:loop())
     end
@@ -56,6 +52,7 @@ function ReaSpeechMain:init_ctx()
   Ctx.on_create = function (ctx)
     Fonts:init(ctx)
   end
+  Ctx()
 end
 
 function ReaSpeechMain:init_logging()

--- a/reascripts/ReaSpeech/source/ui/ASRControls.lua
+++ b/reascripts/ReaSpeech/source/ui/ASRControls.lua
@@ -161,9 +161,9 @@ function ASRControls:init_simple_layout()
     num_columns = #renderers,
 
     render_column = function (column)
-      ImGui.PushItemWidth(ctx, column.width)
+      ImGui.PushItemWidth(Ctx(), column.width)
       Trap(function () renderers[column.num](self, column) end)
-      ImGui.PopItemWidth(ctx)
+      ImGui.PopItemWidth(Ctx())
     end
   }
 end
@@ -204,12 +204,12 @@ function ASRControls:init_advanced_layout()
     num_columns = #renderers,
 
     render_column = function (column)
-      ImGui.PushItemWidth(ctx, column.width)
+      ImGui.PushItemWidth(Ctx(), column.width)
       for row, renderer in ipairs(renderers[column.num]) do
-        if row > 1 then ImGui.Spacing(ctx) end
+        if row > 1 then ImGui.Spacing(Ctx()) end
         Trap(function () renderer(self, column) end)
       end
-      ImGui.PopItemWidth(ctx)
+      ImGui.PopItemWidth(Ctx())
     end
   }
 end
@@ -225,25 +225,25 @@ function ASRControls:render_actions()
   Widgets.disable_if(progress, function()
     local plugin_actions = self.actions:actions()
     for i, action in ipairs(plugin_actions) do
-      if i > 1 then ImGui.SameLine(ctx) end
+      if i > 1 then ImGui.SameLine(Ctx()) end
       action:render()
     end
   end)
 
   if progress then
-    ImGui.SameLine(ctx)
+    ImGui.SameLine(Ctx())
 
-    if ImGui.Button(ctx, "Cancel") then
+    if ImGui.Button(Ctx(), "Cancel") then
       worker:cancel()
     end
 
-    ImGui.SameLine(ctx)
+    ImGui.SameLine(Ctx())
     local overlay = string.format("%.0f%%", progress * 100)
     local status = worker:status()
     if status then
       overlay = overlay .. ' - ' .. status
     end
-    ImGui.ProgressBar(ctx, progress, nil, nil, overlay)
+    ImGui.ProgressBar(Ctx(), progress, nil, nil, overlay)
   end
 end
 
@@ -265,15 +265,15 @@ end
 function ASRControls:render()
   self:check_asr_info()
   self.simple_layout:render()
-  ImGui.Unindent(ctx)
-  ImGui.Dummy(ctx, ReaSpeechControlsUI.MARGIN_LEFT, 0)
-  ImGui.SameLine(ctx)
-  if ImGui.TreeNode(ctx, "Advanced Options") then
+  ImGui.Unindent(Ctx())
+  ImGui.Dummy(Ctx(), ReaSpeechControlsUI.MARGIN_LEFT, 0)
+  ImGui.SameLine(Ctx())
+  if ImGui.TreeNode(Ctx(), "Advanced Options") then
     self.advanced_layout:render()
-    ImGui.TreePop(ctx)
+    ImGui.TreePop(Ctx())
   end
-  ImGui.Indent(ctx)
-  ImGui.Spacing(ctx)
+  ImGui.Indent(Ctx())
+  ImGui.Spacing(Ctx())
   self.actions_layout:render()
 self.alert_popup:render()
 end
@@ -281,7 +281,7 @@ end
 function ASRControls:render_language(column)
   if self.asr_options.language then
     self.language:render()
-    ImGui.Spacing(ctx)
+    ImGui.Spacing(Ctx())
     self.translate:render(column)
   end
 end

--- a/reascripts/ReaSpeech/source/ui/AlertPopup.lua
+++ b/reascripts/ReaSpeech/source/ui/AlertPopup.lua
@@ -36,10 +36,10 @@ function AlertPopup:render_content()
     self.msg()
     return
   end
-  ImGui.Text(ctx, self.msg)
+  ImGui.Text(Ctx(), self.msg)
 
   self:render_separator()
-  if ImGui.Button(ctx, 'OK', self.BUTTON_WIDTH, 0) then
+  if ImGui.Button(Ctx(), 'OK', self.BUTTON_WIDTH, 0) then
     self:close()
   end
 end

--- a/reascripts/ReaSpeech/source/ui/ColumnLayout.lua
+++ b/reascripts/ReaSpeech/source/ui/ColumnLayout.lua
@@ -47,24 +47,24 @@ function ColumnLayout:render()
 end
 
 function ColumnLayout:_column_gap(padding)
-  ImGui.SameLine(ctx, 0, padding)
+  ImGui.SameLine(Ctx(), 0, padding)
 end
 
 function ColumnLayout:_get_avail_width()
-  local avail_width, _ = ImGui.GetContentRegionAvail(ctx)
+  local avail_width, _ = ImGui.GetContentRegionAvail(Ctx())
   return avail_width
 end
 
 function ColumnLayout:_horiz_margin(margin)
-  ImGui.SetCursorPosX(ctx, ImGui.GetCursorPosX(ctx) + margin)
+  ImGui.SetCursorPosX(Ctx(), ImGui.GetCursorPosX(Ctx()) + margin)
 end
 
 function ColumnLayout:_vert_margin(margin, width)
-  ImGui.Dummy(ctx, width, margin)
+  ImGui.Dummy(Ctx(), width, margin)
 end
 
 function ColumnLayout:_with_group(f)
-  ImGui.BeginGroup(ctx)
+  ImGui.BeginGroup(Ctx())
   Trap(f)
-  ImGui.EndGroup(ctx)
+  ImGui.EndGroup(Ctx())
 end

--- a/reascripts/ReaSpeech/source/ui/KeyMap.lua
+++ b/reascripts/ReaSpeech/source/ui/KeyMap.lua
@@ -23,7 +23,7 @@ end
 
 function KeyMap:react()
   for key, binding in pairs(self.bindings) do
-    if ImGui.IsKeyPressed(ctx, key) then
+    if ImGui.IsKeyPressed(Ctx(), key) then
       if type(binding) == 'function' then
         binding()
       elseif type(binding) == 'table' then

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechControlsUI.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechControlsUI.lua
@@ -34,16 +34,16 @@ function ReaSpeechControlsUI:init_tabs()
       label = '+',
       position = 'trailing',
       on_click = function()
-        ImGui.OpenPopup(ctx, 'new-tab-popup')
+        ImGui.OpenPopup(Ctx(), 'new-tab-popup')
       end,
       render = function()
-        if ImGui.BeginPopup(ctx, 'new-tab-popup') then
+        if ImGui.BeginPopup(Ctx(), 'new-tab-popup') then
           for _, menu_item in ipairs(self.plugins:new_tab_menu()) do
-            if ImGui.Selectable(ctx, menu_item.label) then
+            if ImGui.Selectable(Ctx(), menu_item.label) then
               menu_item.on_click()
             end
           end
-          ImGui.EndPopup(ctx)
+          ImGui.EndPopup(Ctx())
         end
       end
     })
@@ -59,20 +59,20 @@ function ReaSpeechControlsUI:init_tabs()
 end
 
 function ReaSpeechControlsUI:render()
-  ImGui.BeginGroup(ctx)
+  ImGui.BeginGroup(Ctx())
   Trap(function()
     Widgets.png('reaspeech-logo-small')
 
     -- Nice big column under the logo to render into, ie
-    -- if ImGui.Button(ctx, 'Metrics') then
+    -- if ImGui.Button(Ctx(), 'Metrics') then
     --   ReaSpeechUI.METRICS = not ReaSpeechUI.METRICS
     -- end
   end)
-  ImGui.EndGroup(ctx)
+  ImGui.EndGroup(Ctx())
 
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
-  ImGui.BeginGroup(ctx)
+  ImGui.BeginGroup(Ctx())
   Trap(function()
     self:render_heading()
 
@@ -83,7 +83,7 @@ function ReaSpeechControlsUI:render()
     end
 
   end)
-  ImGui.EndGroup(ctx)
+  ImGui.EndGroup(Ctx())
 
   -- Drop target applies to last appended item
   -- rendering it in all cases means you can
@@ -93,7 +93,7 @@ function ReaSpeechControlsUI:render()
 end
 
 function ReaSpeechControlsUI:_render_drop_zone()
-  local avail_w, avail_h = ImGui.GetContentRegionAvail(ctx)
+  local avail_w, avail_h = ImGui.GetContentRegionAvail(Ctx())
 
   local drop_zone_height = (avail_h - 10) / #self._drop_zones
 
@@ -114,24 +114,24 @@ function ReaSpeechControlsUI:_render_drop_zone()
 
     local which_theme = drop_zone.hovered and theme_selected or theme
 
-    which_theme:wrap(ctx, function()
-      ImGui.BeginChild(ctx, 'drop-zone-' .. i, avail_w, drop_zone_height, child_flags)
+    which_theme:wrap(Ctx(), function()
+      ImGui.BeginChild(Ctx(), 'drop-zone-' .. i, avail_w, drop_zone_height, child_flags)
       Trap(function()
         drop_zone:render()
       end)
-      ImGui.EndChild(ctx)
-      drop_zone.hovered = ImGui.IsItemHovered(ctx, ImGui.HoveredFlags_AllowWhenBlockedByActiveItem())
+      ImGui.EndChild(Ctx())
+      drop_zone.hovered = ImGui.IsItemHovered(Ctx(), ImGui.HoveredFlags_AllowWhenBlockedByActiveItem())
     end, Trap)
   end
 end
 
 function ReaSpeechControlsUI:_render_drop_target()
-  if ImGui.BeginDragDropTarget(ctx) then
+  if ImGui.BeginDragDropTarget(Ctx()) then
     Trap(function()
       local dragdrop_flags = ImGui.DragDropFlags_AcceptNoPreviewTooltip()
         | (self._dragdrop_flags or ImGui.DragDropFlags_AcceptPeekOnly())
 
-      local payload, count = ImGui.AcceptDragDropPayloadFiles(ctx, nil,
+      local payload, count = ImGui.AcceptDragDropPayloadFiles(Ctx(), nil,
         dragdrop_flags | ImGui.DragDropFlags_AcceptNoDrawDefaultRect())
 
       if not payload then return end
@@ -142,7 +142,7 @@ function ReaSpeechControlsUI:_render_drop_target()
         self:_init_drag_drop(count)
       end
     end)
-    ImGui.EndDragDropTarget(ctx)
+    ImGui.EndDragDropTarget(Ctx())
   elseif self._dropped_files then
     self:_reset_drag_drop()
   end
@@ -151,7 +151,7 @@ end
 function ReaSpeechControlsUI:_init_drag_drop(file_count)
   local files = {}
   for i = 0, file_count do
-    local file_result, file = ImGui.GetDragDropPayloadFile(ctx, i)
+    local file_result, file = ImGui.GetDragDropPayloadFile(Ctx(), i)
     if file_result then
       table.insert(files, file)
     end
@@ -182,7 +182,7 @@ end
 
 function ReaSpeechControlsUI:render_heading()
   local button_size = Fonts.size:get() * 1.7
-  ImGui.PushStyleVar(ctx, ImGui.StyleVar_FrameRounding(), 4)
+  ImGui.PushStyleVar(Ctx(), ImGui.StyleVar_FrameRounding(), 4)
   Trap(function ()
     if Widgets.icon_button(Icons.gear, '##settings', button_size, button_size, 'Settings') then
       local settings_plugin = self.plugins:get_plugin(SettingsPlugin.PLUGIN_KEY)
@@ -194,29 +194,29 @@ function ReaSpeechControlsUI:render_heading()
       end
     end
   end)
-  ImGui.PopStyleVar(ctx)
-  ImGui.SameLine(ctx)
+  ImGui.PopStyleVar(Ctx())
+  ImGui.SameLine(Ctx())
 
-  local avail_w, _ = ImGui.GetContentRegionAvail(ctx)
+  local avail_w, _ = ImGui.GetContentRegionAvail(Ctx())
 
   local logo = IMAGES['heading-logo-tech-audio']
 
   local tab_bar_width = avail_w - logo.width - self.COLUMN_PADDING
 
-  ImGui.BeginChild(ctx, 'tab-bar', tab_bar_width, logo.height)
+  ImGui.BeginChild(Ctx(), 'tab-bar', tab_bar_width, logo.height)
   Trap(function ()
     self.tab_bar:render()
   end)
-  ImGui.EndChild(ctx)
+  ImGui.EndChild(Ctx())
 
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
   Widgets.png(logo)
 end
 
 function ReaSpeechControlsUI:render_input_label(text)
-  ImGui.Text(ctx, text)
-  ImGui.Dummy(ctx, 0, 0)
+  ImGui.Text(Ctx(), text)
+  ImGui.Dummy(Ctx(), 0, 0)
 end
 
 function ReaSpeechControlsUI:render_tab_content()
@@ -224,11 +224,11 @@ function ReaSpeechControlsUI:render_tab_content()
 
   for _, tab in ipairs(self.plugins:tabs()) do
     if tab.tab.key == tab_bar_value then
-      ImGui.BeginChild(ctx, 'tab-content', 0, 0)
+      ImGui.BeginChild(Ctx(), 'tab-content', 0, 0)
       Trap(function()
         tab:render()
       end)
-      ImGui.EndChild(ctx)
+      ImGui.EndChild(Ctx())
     end
 
     if tab.render_bg then tab:render_bg() end

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechUI.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechUI.lua
@@ -105,7 +105,7 @@ end
 
 function ReaSpeechUI:render_content()
   if ReaSpeechUI.METRICS then
-    ImGui.ShowMetricsWindow(ctx)
+    ImGui.ShowMetricsWindow(Ctx())
   end
 
   Trap(function ()

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechWelcomeUI.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechWelcomeUI.lua
@@ -65,42 +65,42 @@ function ReaSpeechWelcomeUI:render_demo_text()
   self:render_heading("Demo Version")
   self:render_text("Please note that this version is a demo and may not be available at all times.")
   self:render_text("For a more reliable experience, you can run ReaSpeech locally using the ")
-  ImGui.SameLine(ctx, 0, 0)
+  ImGui.SameLine(Ctx(), 0, 0)
   Widgets.link("Docker image", ReaUtil.url_opener(self.DOCKER_DOC_URL), self.LINK_COLOR, self.LINK_COLOR)
-  ImGui.SameLine(ctx, 0, 0)
-  ImGui.Text(ctx, ".")
+  ImGui.SameLine(Ctx(), 0, 0)
+  ImGui.Text(Ctx(), ".")
 end
 
 function ReaSpeechWelcomeUI:render_close_button()
-  ImGui.Dummy(ctx, self.WIDTH, self.PADDING - 2)
-  ImGui.SetCursorPosX(ctx, self.PADDING - 2)
-  if ImGui.Button(ctx, "Let's Go!") then
+  ImGui.Dummy(Ctx(), self.WIDTH, self.PADDING - 2)
+  ImGui.SetCursorPosX(Ctx(), self.PADDING - 2)
+  if ImGui.Button(Ctx(), "Let's Go!") then
     self:close()
   end
 end
 
 function ReaSpeechWelcomeUI:render_heading(text)
-  ImGui.PushFont(ctx, Fonts.bold)
+  ImGui.PushFont(Ctx(), Fonts.bold)
   Trap(function ()
-    ImGui.Dummy(ctx, self.WIDTH, self.HEADING_MARGIN)
-    ImGui.SetCursorPosX(ctx, self.PADDING)
-    ImGui.Text(ctx, text)
+    ImGui.Dummy(Ctx(), self.WIDTH, self.HEADING_MARGIN)
+    ImGui.SetCursorPosX(Ctx(), self.PADDING)
+    ImGui.Text(Ctx(), text)
   end)
-  ImGui.PopFont(ctx)
+  ImGui.PopFont(Ctx())
 end
 
 function ReaSpeechWelcomeUI:render_text(text)
-  ImGui.Dummy(ctx, self.WIDTH, self.PARA_MARGIN)
-  ImGui.SetCursorPosX(ctx, self.PADDING)
-  ImGui.Text(ctx, text)
+  ImGui.Dummy(Ctx(), self.WIDTH, self.PARA_MARGIN)
+  ImGui.SetCursorPosX(Ctx(), self.PADDING)
+  ImGui.Text(Ctx(), text)
 end
 
 function ReaSpeechWelcomeUI:render_footer()
-  ImGui.Dummy(ctx, self.WIDTH, self.FOOTER_MARGIN)
+  ImGui.Dummy(Ctx(), self.WIDTH, self.FOOTER_MARGIN)
 
-  local draw_list = ImGui.GetWindowDrawList(ctx)
-  local screen_x, screen_y = ImGui.GetCursorScreenPos(ctx)
-  local cursor_x, cursor_y = ImGui.GetCursorPos(ctx)
+  local draw_list = ImGui.GetWindowDrawList(Ctx())
+  local screen_x, screen_y = ImGui.GetCursorScreenPos(Ctx())
+  local cursor_x, cursor_y = ImGui.GetCursorPos(Ctx())
 
   ImGui.DrawList_AddRectFilled(
     draw_list,
@@ -111,12 +111,12 @@ function ReaSpeechWelcomeUI:render_footer()
     self.FOOTER_BG_COLOR
   )
 
-  ImGui.Dummy(ctx, self.WIDTH, self.FOOTER_HEIGHT)
-  ImGui.SetCursorPos(ctx, cursor_x + self.PADDING, cursor_y + self.PADDING)
+  ImGui.Dummy(Ctx(), self.WIDTH, self.FOOTER_HEIGHT)
+  ImGui.SetCursorPos(Ctx(), cursor_x + self.PADDING, cursor_y + self.PADDING)
 
   Widgets.link("ReaSpeech Website", ReaUtil.url_opener(self.HOME_URL))
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
   Widgets.link("GitHub", ReaUtil.url_opener(self.GITHUB_URL))
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
   Widgets.link("Docker Hub", ReaUtil.url_opener(self.DOCKER_HUB_URL))
 end

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechWidgets.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechWidgets.lua
@@ -17,12 +17,12 @@ function ReaSpeechWidget:init()
 end
 
 function ReaSpeechWidget:render(...)
-  ImGui.PushID(ctx, self.widget_id)
+  ImGui.PushID(Ctx(), self.widget_id)
   local args = ...
   Trap(function()
     self.renderer(self, args)
   end)
-  ImGui.PopID(ctx)
+  ImGui.PopID(Ctx())
 end
 
 function ReaSpeechWidget:render_help_icon()
@@ -35,14 +35,14 @@ function ReaSpeechWidget:render_label(label)
   local options = self.options
   label = label or options.label
 
-  ImGui.Text(ctx, label)
+  ImGui.Text(Ctx(), label)
 
   if label ~= '' and options.help_text then
-    ImGui.SameLine(ctx)
+    ImGui.SameLine(Ctx())
     self:render_help_icon()
   end
 
-  ImGui.Dummy(ctx, 0, 0)
+  ImGui.Dummy(Ctx(), 0, 0)
 end
 
 function ReaSpeechWidget:value()

--- a/reascripts/ReaSpeech/source/ui/SampleMultipleUploadControls.lua
+++ b/reascripts/ReaSpeech/source/ui/SampleMultipleUploadControls.lua
@@ -32,15 +32,15 @@ function SampleMultipleUploadControls:init_layout()
     num_columns = 1,
 
     render_column = function (column)
-      ImGui.PushItemWidth(ctx, column.width)
+      ImGui.PushItemWidth(Ctx(), column.width)
       Trap(function () self:render_controls() end)
-      ImGui.PopItemWidth(ctx)
+      ImGui.PopItemWidth(Ctx())
     end
   }
 
   function SampleMultipleUploadControls:render_controls()
     self.upload_file1:render()
-    ImGui.Dummy(ctx, 0, 5)
+    ImGui.Dummy(Ctx(), 0, 5)
     self.upload_file2:render()
   end
 end

--- a/reascripts/ReaSpeech/source/ui/SettingsControls.lua
+++ b/reascripts/ReaSpeech/source/ui/SettingsControls.lua
@@ -49,9 +49,9 @@ function SettingsControls:init_layout()
 
     render_column = function (column)
       if renderers[column.num] then
-        ImGui.PushItemWidth(ctx, column.width)
+        ImGui.PushItemWidth(Ctx(), column.width)
         Trap(function () renderers[column.num](self, column) end)
-        ImGui.PopItemWidth(ctx)
+        ImGui.PopItemWidth(Ctx())
       end
     end
   }
@@ -79,7 +79,7 @@ function SettingsControls:render_logging()
   ReaSpeechControlsUI:render_input_label('Logging')
 
   self.log_enable:render()
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
   Widgets.disable_if(not self.log_enable:value(), function ()
     self.log_debug:render()

--- a/reascripts/ReaSpeech/source/ui/TranscriptAnnotationsUI.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptAnnotationsUI.lua
@@ -50,11 +50,11 @@ function TranscriptAnnotationsUI:render_content()
   local selected_type = self.annotation_types:selected_type()
 
   if selected_type then
-    ImGui.Spacing(ctx)
+    ImGui.Spacing(Ctx())
 
     self.annotation_types:render_type_options(self.annotation_type)
 
-    ImGui.Spacing(ctx)
+    ImGui.Spacing(Ctx())
   end
 
   self:render_separator()
@@ -64,14 +64,14 @@ end
 
 function TranscriptAnnotationsUI:render_buttons(is_disabled)
   Widgets.disable_if(is_disabled, function()
-    if ImGui.Button(ctx, 'Create', self.BUTTON_WIDTH, 0) then
+    if ImGui.Button(Ctx(), 'Create', self.BUTTON_WIDTH, 0) then
       self:handle_create()
     end
   end)
 
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
-  if ImGui.Button(ctx, 'Close', self.BUTTON_WIDTH, 0) then
+  if ImGui.Button(Ctx(), 'Close', self.BUTTON_WIDTH, 0) then
     self:close()
   end
 end
@@ -196,9 +196,9 @@ function TranscriptAnnotationTypes.take_markers(has_words)
     key = 'take_markers',
     renderer = function ()
       granularity_combo:render()
-      ImGui.Spacing(ctx)
+      ImGui.Spacing(Ctx())
       track_filter_mode:render()
-      ImGui.Spacing(ctx)
+      ImGui.Spacing(Ctx())
       track_selector:render()
     end,
     creator = function (annotations)
@@ -266,7 +266,7 @@ function TranscriptAnnotationTypes.notes_track(has_words)
 
     renderer = function ()
       track_name:render()
-      ImGui.Spacing(ctx)
+      ImGui.Spacing(Ctx())
       granularity_combo:render()
     end,
 

--- a/reascripts/ReaSpeech/source/ui/TranscriptEditor.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptEditor.lua
@@ -79,7 +79,7 @@ function TranscriptEditor:edit_word(index)
 end
 
 function TranscriptEditor:render_content()
-  if not ImGui.IsAnyItemActive(ctx) then
+  if not ImGui.IsAnyItemActive(Ctx()) then
     self.key_bindings:react()
   end
 
@@ -102,13 +102,13 @@ function TranscriptEditor:render_content()
 
   self:render_separator()
 
-  if ImGui.Button(ctx, 'Save', self.BUTTON_WIDTH, 0) then
+  if ImGui.Button(Ctx(), 'Save', self.BUTTON_WIDTH, 0) then
     self:handle_save()
     self:close()
   end
 
-  ImGui.SameLine(ctx)
-  if ImGui.Button(ctx, 'Cancel', self.BUTTON_WIDTH, 0) then
+  ImGui.SameLine(Ctx())
+  if ImGui.Button(Ctx(), 'Cancel', self.BUTTON_WIDTH, 0) then
     self:close()
   end
 end
@@ -117,48 +117,48 @@ function TranscriptEditor:render_word_navigation()
   local words = self.editing.words
   local word_index = self.editing.word_index
   local num_words = #words
-  local spacing = ImGui.GetStyleVar(ctx, ImGui.StyleVar_ItemInnerSpacing())
+  local spacing = ImGui.GetStyleVar(Ctx(), ImGui.StyleVar_ItemInnerSpacing())
 
-  ImGui.PushButtonRepeat(ctx, true)
+  ImGui.PushButtonRepeat(Ctx(), true)
   Trap(function ()
-    if ImGui.ArrowButton(ctx, '##left', ImGui.Dir_Left()) then
+    if ImGui.ArrowButton(Ctx(), '##left', ImGui.Dir_Left()) then
       self:edit_word(self.editing.word_index - 1)
     end
-    ImGui.SameLine(ctx, 0, spacing)
-    if ImGui.ArrowButton(ctx, '##right', ImGui.Dir_Right()) then
+    ImGui.SameLine(Ctx(), 0, spacing)
+    if ImGui.ArrowButton(Ctx(), '##right', ImGui.Dir_Right()) then
       self:edit_word(self.editing.word_index + 1)
     end
   end)
-  ImGui.PopButtonRepeat(ctx)
+  ImGui.PopButtonRepeat(Ctx())
 
-  ImGui.SameLine(ctx)
-  ImGui.AlignTextToFramePadding(ctx)
-  ImGui.Text(ctx, 'Word ' .. word_index .. ' / ' .. num_words)
+  ImGui.SameLine(Ctx())
+  ImGui.AlignTextToFramePadding(Ctx())
+  ImGui.Text(Ctx(), 'Word ' .. word_index .. ' / ' .. num_words)
 
-  ImGui.SameLine(ctx)
-  if ImGui.Button(ctx, 'Add') then
+  ImGui.SameLine(Ctx())
+  if ImGui.Button(Ctx(), 'Add') then
     self:handle_word_add()
   end
   Widgets.tooltip('Add word after current word')
 
-  ImGui.SameLine(ctx, 0, spacing)
+  ImGui.SameLine(Ctx(), 0, spacing)
 
   Widgets.disable_if(num_words <= 1, function()
-    if ImGui.Button(ctx, 'Delete') then
+    if ImGui.Button(Ctx(), 'Delete') then
       self:handle_word_delete()
     end
   end)
   Widgets.tooltip('Delete current word')
 
-  ImGui.SameLine(ctx, 0, spacing)
-  if ImGui.Button(ctx, 'Split') then
+  ImGui.SameLine(Ctx(), 0, spacing)
+  if ImGui.Button(Ctx(), 'Split') then
     self:handle_word_split()
   end
   Widgets.tooltip('Split current word into two words')
 
-  ImGui.SameLine(ctx, 0, spacing)
+  ImGui.SameLine(Ctx(), 0, spacing)
   Widgets.disable_if(word_index >= num_words, function()
-    if ImGui.Button(ctx, 'Merge') then
+    if ImGui.Button(Ctx(), 'Merge') then
       self:handle_word_merge()
     end
   end)
@@ -168,24 +168,24 @@ end
 function TranscriptEditor:render_words()
   local words = self.editing.words
   local num_words = #words
-  local spacing = ImGui.GetStyleVar(ctx, ImGui.StyleVar_ItemInnerSpacing())
+  local spacing = ImGui.GetStyleVar(Ctx(), ImGui.StyleVar_ItemInnerSpacing())
   local edit_requested = nil
 
   for i, word in pairs(words) do
     if self.editing.word_index ~= i then
-      ImGui.PushStyleColor(ctx, ImGui.Col_Button(), 0xffffff33)
+      ImGui.PushStyleColor(Ctx(), ImGui.Col_Button(), 0xffffff33)
     end
     Trap(function()
-      if ImGui.Button(ctx, word.word .. '##' .. i) then
+      if ImGui.Button(Ctx(), word.word .. '##' .. i) then
         edit_requested = i
       end
     end)
     if self.editing.word_index ~= i then
-      ImGui.PopStyleColor(ctx)
+      ImGui.PopStyleColor(Ctx())
     end
 
     if i < num_words and i % self.WORDS_PER_LINE ~= 0 then
-      ImGui.SameLine(ctx, 0, spacing)
+      ImGui.SameLine(Ctx(), 0, spacing)
     end
   end
 
@@ -214,7 +214,7 @@ function TranscriptEditor:render_word_inputs()
 end
 
 function TranscriptEditor:render_word_input()
-  local rv, value = ImGui.InputText(ctx, 'word', self.editing.word.word)
+  local rv, value = ImGui.InputText(Ctx(), 'word', self.editing.word.word)
   if rv then
     value = value:gsub('^%s*(.-)%s*$', '%1')
     if #value > 0 then
@@ -225,7 +225,7 @@ end
 
 function TranscriptEditor:render_time_input(label, value, callback)
   local value_str = reaper.format_timestr(value, '')
-  local rv, new_value = ImGui.InputText(ctx, label, value_str)
+  local rv, new_value = ImGui.InputText(Ctx(), label, value_str)
   if rv then
     callback(reaper.parse_timestr(new_value))
   end
@@ -234,17 +234,17 @@ end
 function TranscriptEditor:render_score_input()
   local color = TranscriptUI.score_color(self.editing.word:score())
   if color then
-    ImGui.PushStyleColor(ctx, ImGui.Col_SliderGrab(), color)
-    ImGui.PushStyleColor(ctx, ImGui.Col_SliderGrabActive(), color)
+    ImGui.PushStyleColor(Ctx(), ImGui.Col_SliderGrab(), color)
+    ImGui.PushStyleColor(Ctx(), ImGui.Col_SliderGrabActive(), color)
   end
   Trap(function ()
-    local rv, value = ImGui.SliderDouble(ctx, 'score', self.editing.word.probability, 0, 1)
+    local rv, value = ImGui.SliderDouble(Ctx(), 'score', self.editing.word.probability, 0, 1)
     if rv then
       self.editing.word.probability = value
     end
   end)
   if color then
-    ImGui.PopStyleColor(ctx, 2)
+    ImGui.PopStyleColor(Ctx(), 2)
   end
 end
 
@@ -256,15 +256,15 @@ function TranscriptEditor:render_word_actions()
     reaper.Main_OnCommand(40044, 0) -- Transport: Play/stop
   end
 
-  local spacing = ImGui.GetStyleVar(ctx, ImGui.StyleVar_ItemInnerSpacing())
-  ImGui.SameLine(ctx, 0, spacing)
+  local spacing = ImGui.GetStyleVar(Ctx(), ImGui.StyleVar_ItemInnerSpacing())
+  ImGui.SameLine(Ctx(), 0, spacing)
 
   if Widgets.icon_button(Icons.stop, '##stop', 27, 27, 'Stop') then
     reaper.Main_OnCommand(1016, 0) -- Transport: Stop
   end
 
-  ImGui.SameLine(ctx)
-  local rv, value = ImGui.Checkbox(ctx, 'sync time selection', self.sync_time_selection)
+  ImGui.SameLine(Ctx())
+  local rv, value = ImGui.Checkbox(Ctx(), 'sync time selection', self.sync_time_selection)
   if rv then
     self.sync_time_selection = value
     if value then
@@ -272,33 +272,33 @@ function TranscriptEditor:render_word_actions()
     end
   end
 
-  ImGui.SameLine(ctx)
-  ImGui.Text(ctx, 'and')
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
+  ImGui.Text(Ctx(), 'and')
+  ImGui.SameLine(Ctx())
   self:render_zoom_combo()
 end
 
 function TranscriptEditor:render_zoom_combo()
-  ImGui.SameLine(ctx)
-  ImGui.Text(ctx, "zoom to")
-  ImGui.SameLine(ctx)
-  ImGui.PushItemWidth(ctx, self.BUTTON_WIDTH)
+  ImGui.SameLine(Ctx())
+  ImGui.Text(Ctx(), "zoom to")
+  ImGui.SameLine(Ctx())
+  ImGui.PushItemWidth(Ctx(), self.BUTTON_WIDTH)
   Trap(function()
     Widgets.disable_if(not self.sync_time_selection, function()
-      if ImGui.BeginCombo(ctx, "##zoom_level", self.zoom_level) then
+      if ImGui.BeginCombo(Ctx(), "##zoom_level", self.zoom_level) then
         Trap(function()
           for _, zoom in pairs(self.ZOOM_LEVEL) do
-            if ImGui.Selectable(ctx, zoom.description, self.zoom_level == zoom.value) then
+            if ImGui.Selectable(Ctx(), zoom.description, self.zoom_level == zoom.value) then
               self.zoom_level = zoom.value
               self:handle_zoom_change()
             end
           end
         end)
-        ImGui.EndCombo(ctx)
+        ImGui.EndCombo(Ctx())
       end
     end)
   end)
-  ImGui.PopItemWidth(ctx)
+  ImGui.PopItemWidth(Ctx())
 end
 
 function TranscriptEditor:offset()

--- a/reascripts/ReaSpeech/source/ui/TranscriptExporter.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptExporter.lua
@@ -139,8 +139,8 @@ function TranscriptExporter:show_success()
     local file_path = self.target_filename:get()
     local filename = PathUtil.get_filename(self.target_filename:get())
 
-    ImGui.Text(ctx, 'Exported ' .. self.export_formats:selected_key() .. ' to: ')
-    ImGui.SameLine(ctx)
+    ImGui.Text(Ctx(), 'Exported ' .. self.export_formats:selected_key() .. ' to: ')
+    ImGui.SameLine(Ctx())
 
     Widgets.link(filename, function()
       ExecProcess.new(PathUtil.get_reveal_command(file_path)):no_wait()
@@ -158,11 +158,11 @@ function TranscriptExporter:render_content()
 
   self.export_formats:render_combo(self.INPUT_WIDTH)
 
-  ImGui.Spacing(ctx)
+  ImGui.Spacing(Ctx())
 
   self.export_formats:render_format_options(self.export_options)
 
-  ImGui.Spacing(ctx)
+  ImGui.Spacing(Ctx())
 
   self:render_file_selector()
 
@@ -174,17 +174,17 @@ end
 function TranscriptExporter:render_file_selector()
   self.file_selector:render()
 
-  ImGui.Spacing(ctx)
+  ImGui.Spacing(Ctx())
 
   self.apply_extension:render()
 
-  ImGui.Spacing(ctx)
+  ImGui.Spacing(Ctx())
 
   local show_target_filename = self.file_selector:value() == ''
     or self.target_filename:get() ~= self.file_selector:value()
 
   if show_target_filename then
-    ImGui.Text(ctx, 'Target File: ' .. self.target_filename_display:get())
+    ImGui.Text(Ctx(), 'Target File: ' .. self.target_filename_display:get())
   end
 
   if self.target_filename_exists:get() then
@@ -194,15 +194,15 @@ end
 
 function TranscriptExporter:render_buttons()
   Widgets.disable_if(self.file_selector:value() == '', function()
-    if ImGui.Button(ctx, 'Export', self.BUTTON_WIDTH, 0) then
+    if ImGui.Button(Ctx(), 'Export', self.BUTTON_WIDTH, 0) then
       if self:handle_export() then
         self:show_success()
       end
     end
   end)
 
-  ImGui.SameLine(ctx)
-  if ImGui.Button(ctx, 'Cancel', self.BUTTON_WIDTH, 0) then
+  ImGui.SameLine(Ctx())
+  if ImGui.Button(Ctx(), 'Cancel', self.BUTTON_WIDTH, 0) then
     self:close()
   end
 end
@@ -239,13 +239,13 @@ TranscriptExporterFormats = Polo {
 }
 
 function TranscriptExporterFormats:render_combo(width)
-  ImGui.Text(ctx, 'Format')
-  ImGui.SetNextItemWidth(ctx, width)
-  if ImGui.BeginCombo(ctx, "##format", self.selected_format_key) then
+  ImGui.Text(Ctx(), 'Format')
+  ImGui.SetNextItemWidth(Ctx(), width)
+  if ImGui.BeginCombo(Ctx(), "##format", self.selected_format_key) then
     Trap(function()
       for _, format in pairs(self.formatters) do
         local is_selected = self.selected_format_key == format.key
-        if ImGui.Selectable(ctx, format.key, is_selected) then
+        if ImGui.Selectable(Ctx(), format.key, is_selected) then
           self.selected_format_key = format.key
 
           if self.on_change then
@@ -253,11 +253,11 @@ function TranscriptExporterFormats:render_combo(width)
           end
         end
         if is_selected then
-          ImGui.SetItemDefaultFocus(ctx)
+          ImGui.SetItemDefaultFocus(Ctx())
         end
       end
     end)
-    ImGui.EndCombo(ctx)
+    ImGui.EndCombo(Ctx())
   end
 end
 
@@ -325,7 +325,7 @@ function TranscriptExportFormat.exporter_json()
 end
 
 function TranscriptExportFormat.options_json(options)
-  local rv, value = ImGui.Checkbox(ctx, 'One Object per Transcript Segment', options.object_per_segment)
+  local rv, value = ImGui.Checkbox(Ctx(), 'One Object per Transcript Segment', options.object_per_segment)
   if rv then
     options.object_per_segment = value
   end
@@ -357,26 +357,26 @@ end
 function TranscriptExportFormat.options_srt(options)
   local rv, value
 
-  rv, value = ImGui.InputText(ctx, 'X1', options.coords_x1, ImGui.InputTextFlags_CharsDecimal())
+  rv, value = ImGui.InputText(Ctx(), 'X1', options.coords_x1, ImGui.InputTextFlags_CharsDecimal())
   if rv then
     options.coords_x1 = TranscriptExportFormat.strip_non_numeric(value)
   end
 
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
-  rv, value = ImGui.InputText(ctx, 'Y1', options.coords_y1, ImGui.InputTextFlags_CharsDecimal())
+  rv, value = ImGui.InputText(Ctx(), 'Y1', options.coords_y1, ImGui.InputTextFlags_CharsDecimal())
   if rv then
     options.coords_y1 = TranscriptExportFormat.strip_non_numeric(value)
   end
 
-  rv, value = ImGui.InputText(ctx, 'X2', options.coords_x2, ImGui.InputTextFlags_CharsDecimal())
+  rv, value = ImGui.InputText(Ctx(), 'X2', options.coords_x2, ImGui.InputTextFlags_CharsDecimal())
   if rv then
     options.coords_x2 = TranscriptExportFormat.strip_non_numeric(value)
   end
 
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
-  rv, value = ImGui.InputText(ctx, 'Y2', options.coords_y2, ImGui.InputTextFlags_CharsDecimal())
+  rv, value = ImGui.InputText(Ctx(), 'Y2', options.coords_y2, ImGui.InputTextFlags_CharsDecimal())
   if rv then
     options.coords_y2 = TranscriptExportFormat.strip_non_numeric(value)
   end
@@ -407,24 +407,24 @@ function TranscriptExportFormat.options_csv(options)
     end
   end
 
-  if ImGui.BeginCombo(ctx, 'Delimiter', selected_delimiter.name) then
+  if ImGui.BeginCombo(Ctx(), 'Delimiter', selected_delimiter.name) then
     Trap(function()
       for _, delimiter in ipairs(delimiters) do
         local is_selected = options.delimiter == delimiter.char
-        if ImGui.Selectable(ctx, delimiter.name, is_selected) then
+        if ImGui.Selectable(Ctx(), delimiter.name, is_selected) then
           options.delimiter = delimiter.char
         end
         if is_selected then
-          ImGui.SetItemDefaultFocus(ctx)
+          ImGui.SetItemDefaultFocus(Ctx())
         end
       end
     end)
-    ImGui.EndCombo(ctx)
+    ImGui.EndCombo(Ctx())
   end
 
-  ImGui.Spacing(ctx)
+  ImGui.Spacing(Ctx())
 
-  local rv, value = ImGui.Checkbox(ctx, 'Include Header Row', options.include_header_row)
+  local rv, value = ImGui.Checkbox(Ctx(), 'Include Header Row', options.include_header_row)
   if rv then
     options.include_header_row = value
   end

--- a/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
@@ -61,7 +61,7 @@ end
 
 function TranscriptImporter:render_buttons()
   -- alternatively we could do a disable-button-if-no-file thing
-  if ImGui.Button(ctx, 'Import', self.BUTTON_WIDTH, 0) then
+  if ImGui.Button(Ctx(), 'Import', self.BUTTON_WIDTH, 0) then
     local filepath = self.file_selector:value()
     if filepath == '' then
       self:show_error('No file selected')
@@ -78,9 +78,9 @@ function TranscriptImporter:render_buttons()
     end
   end
 
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
-  if ImGui.Button(ctx, 'Close', self.BUTTON_WIDTH, 0) then
+  if ImGui.Button(Ctx(), 'Close', self.BUTTON_WIDTH, 0) then
     self:close()
   end
 end

--- a/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
@@ -146,20 +146,20 @@ function TranscriptUI:confirm_close()
   end
 
   self.confirmation_popup:show('Transcript not saved!', function()
-    ImGui.Text(ctx, "This transcript hasn't been saved/exported. Are you sure you want to close it?")
-    ImGui.Separator(ctx)
-    if ImGui.Button(ctx, 'Cancel') then
+    ImGui.Text(Ctx(), "This transcript hasn't been saved/exported. Are you sure you want to close it?")
+    ImGui.Separator(Ctx())
+    if ImGui.Button(Ctx(), 'Cancel') then
       self.confirmation_popup:close()
     end
 
-    ImGui.SameLine(ctx)
-    if ImGui.Button(ctx, 'Close without Saving') then
+    ImGui.SameLine(Ctx())
+    if ImGui.Button(Ctx(), 'Close without Saving') then
       self.confirmation_popup:close()
       app.plugins:remove_plugin(self)
     end
 
-    ImGui.SameLine(ctx)
-    if ImGui.Button(ctx, 'Save') then
+    ImGui.SameLine(Ctx())
+    if ImGui.Button(Ctx(), 'Save') then
       self.confirmation_popup:close()
       self.transcript_exporter.on_export = function()
         app.plugins:remove_plugin(self)
@@ -189,7 +189,7 @@ end
 
 function TranscriptUI:clipper()
   if not ImGui.ValidatePtr(self._clipper, 'ImGui_ListClipper*') then
-    self._clipper = ImGui.CreateListClipper(ctx)
+    self._clipper = ImGui.CreateListClipper(Ctx())
   end
 
   return self._clipper
@@ -306,13 +306,13 @@ end
 
 function TranscriptUI:_drop_zone_renderer(text, files)
   return function(_)
-    Fonts.wrap(ctx, Fonts.bigboi, function()
-      local text_width, _ = ImGui.CalcTextSize(ctx, text)
-      local _, y = ImGui.GetContentRegionMax(ctx)
+    Fonts.wrap(Ctx(), Fonts.bigboi, function()
+      local text_width, _ = ImGui.CalcTextSize(Ctx(), text)
+      local _, y = ImGui.GetContentRegionMax(Ctx())
 
-      ImGui.SetCursorPosX(ctx, (ImGui.GetWindowWidth(ctx) - text_width) / 2)
-      ImGui.SetCursorPosY(ctx, y / 3)
-      ImGui.Text(ctx, text)
+      ImGui.SetCursorPosX(Ctx(), (ImGui.GetWindowWidth(Ctx()) - text_width) / 2)
+      ImGui.SetCursorPosY(Ctx(), y / 3)
+      ImGui.Text(Ctx(), text)
     end, Trap)
 
     self:_render_drop_zone_files(files)
@@ -320,13 +320,13 @@ function TranscriptUI:_drop_zone_renderer(text, files)
 end
 
 function TranscriptUI:_render_drop_zone_files(files)
-  Fonts.wrap(ctx, Fonts.big, function()
+  Fonts.wrap(Ctx(), Fonts.big, function()
     for _, file in ipairs(files) do
       local text = PathUtil.get_filename(file)
-      local text_width, _ = ImGui.CalcTextSize(ctx, text)
+      local text_width, _ = ImGui.CalcTextSize(Ctx(), text)
 
-      ImGui.SetCursorPosX(ctx, (ImGui.GetWindowWidth(ctx) - text_width) / 2)
-      ImGui.Text(ctx, text)
+      ImGui.SetCursorPosX(Ctx(), (ImGui.GetWindowWidth(Ctx()) - text_width) / 2)
+      ImGui.Text(Ctx(), text)
     end
   end, Trap)
 end
@@ -343,54 +343,54 @@ function TranscriptUI:render()
 end
 
 function TranscriptUI:render_name()
-  ImGui.PushFont(ctx, Fonts.big)
+  ImGui.PushFont(Ctx(), Fonts.big)
   Trap(function()
     if self.editing_name then
       self.name_editor:render()
     else
-      ImGui.Dummy(ctx, 1, 2)
-      ImGui.Dummy(ctx, 2, 0)
-      ImGui.SameLine(ctx)
+      ImGui.Dummy(Ctx(), 1, 2)
+      ImGui.Dummy(Ctx(), 2, 0)
+      ImGui.SameLine(Ctx())
 
       if #self.transcript.name < 1 then
-        ImGui.Text(ctx, "(Untitled)")
+        ImGui.Text(Ctx(), "(Untitled)")
       else
-        ImGui.Text(ctx, self.transcript.name)
+        ImGui.Text(Ctx(), self.transcript.name)
       end
-      ImGui.SameLine(ctx)
+      ImGui.SameLine(Ctx())
       local icon_size = Fonts.size:get() - 1
       if Widgets.icon(Icons.pencil, "##edit_name", icon_size, icon_size, "Edit") then
         self._original_transcript_name = self.transcript.name
         self.editing_name = true
       end
-      ImGui.Dummy(ctx, 1, 2)
+      ImGui.Dummy(Ctx(), 1, 2)
     end
   end)
-  ImGui.PopFont(ctx)
+  ImGui.PopFont(Ctx())
 end
 
 function TranscriptUI:render_result_actions()
   self:render_annotations_button()
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
   self:render_export()
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
   self:render_clear()
 end
 
 function TranscriptUI:render_annotations_button()
-  if ImGui.Button(ctx, "Create Markers") then
+  if ImGui.Button(Ctx(), "Create Markers") then
     self.annotations:present()
   end
 end
 
 function TranscriptUI:render_export()
-  if ImGui.Button(ctx, "Export") then
+  if ImGui.Button(Ctx(), "Export") then
     self:handle_export()
   end
 end
 
 function TranscriptUI:render_clear()
-  if ImGui.Button(ctx, "Clear") then
+  if ImGui.Button(Ctx(), "Clear") then
     self:handle_transcript_clear()
   end
 end
@@ -398,22 +398,22 @@ end
 function TranscriptUI:render_options()
   local rv, value
 
-  rv, value = ImGui.Checkbox(ctx, "Auto Play", self.autoplay)
+  rv, value = ImGui.Checkbox(Ctx(), "Auto Play", self.autoplay)
   if rv then
     self.autoplay = value
   end
 
   if self.transcript:has_words() then
-    ImGui.SameLine(ctx)
+    ImGui.SameLine(Ctx())
 
-    rv, value = ImGui.Checkbox(ctx, "Words", self.words)
+    rv, value = ImGui.Checkbox(Ctx(), "Words", self.words)
     if rv then
       self.words = value
     end
 
     if self.words then
-      ImGui.SameLine(ctx)
-      rv, value = ImGui.Checkbox(ctx, "Colorize", self.colorize_words)
+      ImGui.SameLine(Ctx())
+      rv, value = ImGui.Checkbox(Ctx(), "Colorize", self.colorize_words)
       if rv then
         self.colorize_words = value
       end
@@ -422,15 +422,15 @@ function TranscriptUI:render_options()
 end
 
 function TranscriptUI:render_search(column)
-  ImGui.SetCursorPosX(ctx, ImGui.GetWindowWidth(ctx) - column.width - self.ACTIONS_MARGIN)
-  ImGui.PushItemWidth(ctx, column.width)
+  ImGui.SetCursorPosX(Ctx(), ImGui.GetWindowWidth(Ctx()) - column.width - self.ACTIONS_MARGIN)
+  ImGui.PushItemWidth(Ctx(), column.width)
   Trap(function()
-    local search_changed, search = ImGui.InputTextWithHint(ctx, '##search', 'Search', self.transcript.search)
+    local search_changed, search = ImGui.InputTextWithHint(Ctx(), '##search', 'Search', self.transcript.search)
     if search_changed then
       self:handle_search(search)
     end
   end)
-  ImGui.PopItemWidth(ctx)
+  ImGui.PopItemWidth(Ctx())
 end
 
 function TranscriptUI:handle_export()
@@ -456,10 +456,10 @@ function TranscriptUI:render_table()
     imgui_id = "transcript-untitled"
   end
 
-  ImGui.PushID(ctx, imgui_id)
-  if ImGui.BeginTable(ctx, "results", num_columns, self.table_flags(true), 0, -10) then
+  ImGui.PushID(Ctx(), imgui_id)
+  if ImGui.BeginTable(Ctx(), "results", num_columns, self.table_flags(true), 0, -10) then
     Trap(function ()
-      ImGui.TableSetupColumn(ctx, "##actions", ImGui.TableColumnFlags_NoSort(), 20)
+      ImGui.TableSetupColumn(Ctx(), "##actions", ImGui.TableColumnFlags_NoSort(), 20)
 
       for _, column in pairs(columns) do
         local column_flags = 0
@@ -476,14 +476,14 @@ function TranscriptUI:render_table()
           init_width = self.LARGE_COLUMN_WIDTH
         end
         -- reaper.ShowConsoleMsg(string.format('column %s: %s / flags: %s\n', column, default_hide, column_flags))
-        ImGui.TableSetupColumn(ctx, column, column_flags, init_width)
+        ImGui.TableSetupColumn(Ctx(), column, column_flags, init_width)
       end
 
-      ImGui.TableSetupScrollFreeze(ctx, 0, 1)
+      ImGui.TableSetupScrollFreeze(Ctx(), 0, 1)
 
       local clipper = self:clipper()
       local items_count = #self.transcript + 1
-      local items_height = ImGui.GetTextLineHeightWithSpacing(ctx)
+      local items_height = ImGui.GetTextLineHeightWithSpacing(Ctx())
 
       ImGui.ListClipper_Begin(clipper, items_count, items_height)
 
@@ -492,24 +492,24 @@ function TranscriptUI:render_table()
 
         for row = display_start, display_end - 1 do
           if row == 0 then
-            ImGui.TableHeadersRow(ctx)
+            ImGui.TableHeadersRow(Ctx())
             self:sort_table()
           else
             local segment = self.transcript:get_segment(row)
-            ImGui.TableNextRow(ctx)
-            ImGui.TableNextColumn(ctx)
+            ImGui.TableNextRow(Ctx())
+            ImGui.TableNextColumn(Ctx())
             self:render_segment_actions(segment, row)
             for _, column in pairs(columns) do
-              ImGui.TableNextColumn(ctx)
+              ImGui.TableNextColumn(Ctx())
               self:render_table_cell(segment, column)
             end
           end
         end
       end
     end)
-    ImGui.EndTable(ctx)
+    ImGui.EndTable(Ctx())
   end
-  ImGui.PopID(ctx)
+  ImGui.PopID(Ctx())
 end
 
 function TranscriptUI:render_segment_actions(segment, index)
@@ -520,8 +520,8 @@ function TranscriptUI:render_segment_actions(segment, index)
     self.transcript_editor:edit_segment(segment, index)
   end
 
-  if ImGui.IsItemHovered(ctx) then
-    ImGui.SetMouseCursor(ctx, ImGui.MouseCursor_Hand())
+  if ImGui.IsItemHovered(Ctx()) then
+    ImGui.SetMouseCursor(Ctx(), ImGui.MouseCursor_Hand())
   end
 end
 
@@ -531,9 +531,9 @@ function TranscriptUI:render_table_cell(segment, column)
   elseif column == "score" then
     self:render_score(segment:get(column, 0.0))
   elseif column == 'start' then
-    ImGui.Text(ctx, reaper.format_timestr(segment:timeline_start_time(), ''))
+    ImGui.Text(Ctx(), reaper.format_timestr(segment:timeline_start_time(), ''))
   elseif column == 'end' then
-    ImGui.Text(ctx, reaper.format_timestr(segment:timeline_end_time(), ''))
+    ImGui.Text(Ctx(), reaper.format_timestr(segment:timeline_end_time(), ''))
   else
     local value = segment:get(column)
     if type(value) == 'table' then
@@ -541,7 +541,7 @@ function TranscriptUI:render_table_cell(segment, column)
     elseif math.type(value) == 'float' then
       value = self.FLOAT_FORMAT:format(value)
     end
-    ImGui.Text(ctx, tostring(value))
+    ImGui.Text(Ctx(), tostring(value))
   end
 end
 
@@ -561,9 +561,9 @@ function TranscriptUI:render_text_words(segment, _)
   if segment.words then
     for i, word in pairs(segment.words) do
       if i > 1 then
-        ImGui.SameLine(ctx, 0, 0)
-        ImGui.Text(ctx, ' ')
-        ImGui.SameLine(ctx, 0, 0)
+        ImGui.SameLine(Ctx(), 0, 0)
+        ImGui.Text(Ctx(), ' ')
+        ImGui.SameLine(Ctx(), 0, 0)
       end
       local color = nil
       if self.colorize_words then
@@ -578,12 +578,12 @@ function TranscriptUI:render_score(value)
   local w, h = 50 * value, 3
   local color = self.score_color(value)
   if color then
-    local draw_list = ImGui.GetWindowDrawList(ctx)
-    local x, y = ImGui.GetCursorScreenPos(ctx)
+    local draw_list = ImGui.GetWindowDrawList(Ctx())
+    local x, y = ImGui.GetCursorScreenPos(Ctx())
     y = y + 7
     ImGui.DrawList_AddRectFilled(draw_list, x, y, x + w, y + h, color)
   end
-  ImGui.Dummy(ctx, w, h)
+  ImGui.Dummy(Ctx(), w, h)
 end
 
 function TranscriptUI.score_color(value)
@@ -603,7 +603,7 @@ function TranscriptUI.score_color(value)
 end
 
 function TranscriptUI:sort_table()
-  local specs_dirty, has_specs = ImGui.TableNeedSort(ctx)
+  local specs_dirty, has_specs = ImGui.TableNeedSort(Ctx())
   if not specs_dirty then return end
 
   if not has_specs then
@@ -617,7 +617,7 @@ function TranscriptUI:sort_table()
 
   for next_id = 0, math.huge do
     local ok, col_idx, _, sort_direction =
-      ImGui.TableGetColumnSortSpecs(ctx, next_id)
+      ImGui.TableGetColumnSortSpecs(Ctx(), next_id)
     if not ok then break end
 
     column = columns[col_idx]

--- a/reascripts/ReaSpeech/source/ui/Widgets.lua
+++ b/reascripts/ReaSpeech/source/ui/Widgets.lua
@@ -16,37 +16,37 @@ function Widgets.disable_if(predicate, f, tooltip)
 
   local imgui_id = 'disabled##' .. (tooltip or '')
 
-  ImGui.BeginDisabled(ctx, true)
+  ImGui.BeginDisabled(Ctx(), true)
   Trap(function ()
     if tooltip then
       local flags = ImGui.ChildFlags_None()
                   | ImGui.ChildFlags_AutoResizeX()
                   | ImGui.ChildFlags_AutoResizeY()
-      ImGui.BeginChild(ctx, imgui_id, 0, 0, flags)
+      ImGui.BeginChild(Ctx(), imgui_id, 0, 0, flags)
     end
 
     Trap(f)
 
     if tooltip then
-      ImGui.EndChild(ctx)
+      ImGui.EndChild(Ctx())
     end
   end)
-  ImGui.EndDisabled(ctx)
+  ImGui.EndDisabled(Ctx())
 
   if tooltip then
-    ImGui.SetItemTooltip(ctx, tooltip)
+    ImGui.SetItemTooltip(Ctx(), tooltip)
   end
 end
 
 function Widgets.icon(icon, id, w, h, tooltip, color, hover_color)
   assert(tooltip, 'missing tooltip for icon')
   color = color or 0xffffffff
-  local x, y = ImGui.GetCursorScreenPos(ctx)
-  local rv = ImGui.InvisibleButton(ctx, id, w, h)
-  if ImGui.IsItemHovered(ctx) then
+  local x, y = ImGui.GetCursorScreenPos(Ctx())
+  local rv = ImGui.InvisibleButton(Ctx(), id, w, h)
+  if ImGui.IsItemHovered(Ctx()) then
     color = hover_color or color
   end
-  local dl = ImGui.GetWindowDrawList(ctx)
+  local dl = ImGui.GetWindowDrawList(Ctx())
   icon(dl, x, y, w, h, color)
   Widgets.tooltip(tooltip)
   return rv
@@ -55,9 +55,9 @@ end
 function Widgets.icon_button(icon, id, w, h, tooltip, color)
   assert(tooltip, 'missing tooltip for icon')
   color = color or 0xffffffff
-  local x, y = ImGui.GetCursorScreenPos(ctx)
-  local rv = ImGui.Button(ctx, id, w, h)
-  local dl = ImGui.GetWindowDrawList(ctx)
+  local x, y = ImGui.GetCursorScreenPos(Ctx())
+  local rv = ImGui.Button(Ctx(), id, w, h)
+  local dl = ImGui.GetWindowDrawList(Ctx())
   icon(dl, x + w * 0.2, y + h * 0.2, w * 0.6, h * 0.6, color)
   Widgets.tooltip(tooltip)
   return rv
@@ -67,22 +67,22 @@ function Widgets.link(text, onclick, text_color, underline_color)
   text_color = text_color or 0xffffffff
   underline_color = underline_color or 0xffffffa0
 
-  ImGui.TextColored(ctx, text_color, text)
+  ImGui.TextColored(Ctx(), text_color, text)
 
-  if ImGui.IsItemHovered(ctx) then
-    local rect_min_x, rect_min_y = ImGui.GetItemRectMin(ctx)
-    local rect_max_x, _ = ImGui.GetItemRectMax(ctx)
-    local _, rect_size_y = ImGui.GetItemRectSize(ctx)
+  if ImGui.IsItemHovered(Ctx()) then
+    local rect_min_x, rect_min_y = ImGui.GetItemRectMin(Ctx())
+    local rect_max_x, _ = ImGui.GetItemRectMax(Ctx())
+    local _, rect_size_y = ImGui.GetItemRectSize(Ctx())
     local line_y = rect_min_y + rect_size_y - 1
 
     ImGui.DrawList_AddLine(
-      ImGui.GetWindowDrawList(ctx),
+      ImGui.GetWindowDrawList(Ctx()),
       rect_min_x, line_y, rect_max_x, line_y,
       underline_color, 1.0)
-    ImGui.SetMouseCursor(ctx, ImGui.MouseCursor_Hand())
+    ImGui.SetMouseCursor(Ctx(), ImGui.MouseCursor_Hand())
   end
 
-  if ImGui.IsItemClicked(ctx) then
+  if ImGui.IsItemClicked(Ctx()) then
     onclick()
   end
 end
@@ -102,25 +102,25 @@ function Widgets.png(image_key)
     image.imgui_image = ImGui.CreateImageFromMem(image.bytes)
   end
 
-  ImGui.Image(ctx, image.imgui_image, image.width, image.height)
+  ImGui.Image(Ctx(), image.imgui_image, image.width, image.height)
 end
 
 function Widgets.tooltip(text)
-  if not ImGui.IsItemHovered(ctx, ImGui.HoveredFlags_DelayNormal()) or
-     not ImGui.BeginTooltip(ctx)
+  if not ImGui.IsItemHovered(Ctx(), ImGui.HoveredFlags_DelayNormal()) or
+     not ImGui.BeginTooltip(Ctx())
   then return end
 
   Trap(function()
-    ImGui.PushTextWrapPos(ctx, ImGui.GetFontSize(ctx) * Widgets.TOOLTIP_WRAP_CHARS)
+    ImGui.PushTextWrapPos(Ctx(), ImGui.GetFontSize(Ctx()) * Widgets.TOOLTIP_WRAP_CHARS)
     Trap(function()
-      ImGui.Text(ctx, text)
+      ImGui.Text(Ctx(), text)
     end)
-    ImGui.PopTextWrapPos(ctx)
+    ImGui.PopTextWrapPos(Ctx())
   end)
 
-  ImGui.EndTooltip(ctx)
+  ImGui.EndTooltip(Ctx())
 end
 
 function Widgets.warning(text)
-  ImGui.TextColored(ctx, Theme.COLORS.bold_red, text)
+  ImGui.TextColored(Ctx(), Theme.COLORS.bold_red, text)
 end

--- a/reascripts/ReaSpeech/source/ui/widgets/Button.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/Button.lua
@@ -38,7 +38,7 @@ Button.renderer = function(self)
   end
 
   Widgets.disable_if(disabled, function()
-    if ImGui.Button(ctx, options.label, options.width) then
+    if ImGui.Button(Ctx(), options.label, options.width) then
       Trap(options.on_click)
     end
   end)

--- a/reascripts/ReaSpeech/source/ui/widgets/ButtonBar.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/ButtonBar.lua
@@ -31,10 +31,10 @@ ButtonBar.new = function (options)
   local with_button_color = function (selected, f)
     local color = Theme.COLORS.dark_gray_translucent
     if selected then color = Theme.COLORS.medium_gray_opaque end
-    ImGui.PushStyleColor(ctx, ImGui.Col_Button(), color)
-    ImGui.PushStyleColor(ctx, ImGui.Col_ButtonHovered(), color)
+    ImGui.PushStyleColor(Ctx(), ImGui.Col_Button(), color)
+    ImGui.PushStyleColor(Ctx(), ImGui.Col_ButtonHovered(), color)
     Trap(f)
-    ImGui.PopStyleColor(ctx, 2)
+    ImGui.PopStyleColor(Ctx(), 2)
   end
 
   o.layout = ColumnLayout.new {
@@ -51,7 +51,7 @@ ButtonBar.new = function (options)
 
       local button_label, model_name = table.unpack(options.buttons[column.num])
       with_button_color(o:value() == model_name, function ()
-        if ImGui.Button(ctx, button_label, column.width) then
+        if ImGui.Button(Ctx(), button_label, column.width) then
           o:set(model_name)
         end
       end)

--- a/reascripts/ReaSpeech/source/ui/widgets/Checkbox.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/Checkbox.lua
@@ -52,11 +52,11 @@ Checkbox.renderer = function (self, column)
   end
 
   Widgets.disable_if(self.options.disabled_if(), function()
-    local rv, value = ImGui.Checkbox(ctx, label, self:value())
+    local rv, value = ImGui.Checkbox(Ctx(), label, self:value())
 
     if options.help_text then
-      ImGui.SameLine(ctx)
-      ImGui.SetCursorPosY(ctx, ImGui.GetCursorPosY(ctx) + 7)
+      ImGui.SameLine(Ctx())
+      ImGui.SetCursorPosY(Ctx(), ImGui.GetCursorPosY(Ctx()) + 7)
       self:render_help_icon()
     end
 

--- a/reascripts/ReaSpeech/source/ui/widgets/Combo.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/Combo.lua
@@ -40,16 +40,16 @@ Combo.renderer = function (self)
   local item_label = options.item_labels[self:value()] or ""
   local combo_flags = ImGui.ComboFlags_HeightLarge()
 
-  if ImGui.BeginCombo(ctx, imgui_label, item_label, combo_flags) then
+  if ImGui.BeginCombo(Ctx(), imgui_label, item_label, combo_flags) then
     Trap(function()
       for _, item in pairs(options.items) do
         local is_selected = (item == self:value())
-        if ImGui.Selectable(ctx, options.item_labels[item], is_selected) then
+        if ImGui.Selectable(Ctx(), options.item_labels[item], is_selected) then
           self:set(item)
         end
       end
     end)
-    ImGui.EndCombo(ctx)
+    ImGui.EndCombo(Ctx())
   end
 end
 

--- a/reascripts/ReaSpeech/source/ui/widgets/FileSelector.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/FileSelector.lua
@@ -90,23 +90,23 @@ end
 FileSelector.renderer = function(self)
   local options = self.options
 
-  ImGui.Text(ctx, options.label)
+  ImGui.Text(Ctx(), options.label)
 
   FileSelector.render_jsapi_notice(self)
 
   options.button:render()
-  ImGui.SameLine(ctx)
+  ImGui.SameLine(Ctx())
 
   local w, _
   if not options.input_width then
-    w, _ = ImGui.GetContentRegionAvail(ctx)
+    w, _ = ImGui.GetContentRegionAvail(Ctx())
   else
     w = options.input_width
   end
 
-  ImGui.SetNextItemWidth(ctx, w)
+  ImGui.SetNextItemWidth(Ctx(), w)
   local hint = '...or type one here.'
-  local file_changed, file = ImGui.InputTextWithHint(ctx, '##file', hint, self:value())
+  local file_changed, file = ImGui.InputTextWithHint(Ctx(), '##file', hint, self:value())
   if file_changed then
     self:set(file)
   end
@@ -117,14 +117,14 @@ FileSelector.render_jsapi_notice = function(self)
     return
   end
 
-  local _, spacing_v = ImGui.GetStyleVar(ctx, ImGui.StyleVar_ItemSpacing())
-  ImGui.PushStyleVar(ctx, ImGui.StyleVar_ItemSpacing(), 0, spacing_v)
-  ImGui.Text(ctx, "To enable file selector, ")
-  ImGui.SameLine(ctx)
+  local _, spacing_v = ImGui.GetStyleVar(Ctx(), ImGui.StyleVar_ItemSpacing())
+  ImGui.PushStyleVar(Ctx(), ImGui.StyleVar_ItemSpacing(), 0, spacing_v)
+  ImGui.Text(Ctx(), "To enable file selector, ")
+  ImGui.SameLine(Ctx())
   Widgets.link('install js_ReaScriptAPI', ReaUtil.url_opener(FileSelector.JSREASCRIPT_URL))
-  ImGui.SameLine(ctx)
-  ImGui.Text(ctx, ".")
-  ImGui.PopStyleVar(ctx)
+  ImGui.SameLine(Ctx())
+  ImGui.Text(Ctx(), ".")
+  ImGui.PopStyleVar(Ctx())
 end
 
 return FileSelector

--- a/reascripts/ReaSpeech/source/ui/widgets/ListBox.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/ListBox.lua
@@ -40,7 +40,7 @@ ListBox.renderer = function(self)
   local imgui_label = ("##%s"):format(options.label)
 
   local needs_update = false
-  if ImGui.BeginListBox(ctx, imgui_label) then
+  if ImGui.BeginListBox(Ctx(), imgui_label) then
     Trap(function()
       local current = self:value()
       local new_value = {}
@@ -48,23 +48,23 @@ ListBox.renderer = function(self)
         new_value[item] = current[item] or false
         local is_selected = current[item]
         local label = options.item_labels[item]
-        ImGui.PushID(ctx, 'item' .. i)
+        ImGui.PushID(Ctx(), 'item' .. i)
         Trap(function()
-          local result, now_selected = ImGui.Selectable(ctx, label, is_selected)
+          local result, now_selected = ImGui.Selectable(Ctx(), label, is_selected)
 
           if result and is_selected ~= now_selected then
             needs_update = true
             new_value[item] = now_selected
           end
         end)
-        ImGui.PopID(ctx)
+        ImGui.PopID(Ctx())
       end
 
       if needs_update then
         self:set(new_value)
       end
     end)
-    ImGui.EndListBox(ctx)
+    ImGui.EndListBox(Ctx())
   end
 end
 

--- a/reascripts/ReaSpeech/source/ui/widgets/NumberInput.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/NumberInput.lua
@@ -39,9 +39,9 @@ NumberInput.renderer = function (self)
 
   local imgui_label = ("##%s"):format(options.label)
 
-  local rv, value = ImGui.InputInt(ctx, imgui_label, self:value())
+  local rv, value = ImGui.InputInt(Ctx(), imgui_label, self:value())
 
-  if rv and ImGui.IsItemDeactivatedAfterEdit(ctx) then
+  if rv and ImGui.IsItemDeactivatedAfterEdit(Ctx()) then
     self:set(value)
   end
 end

--- a/reascripts/ReaSpeech/source/ui/widgets/TabBar.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/TabBar.lua
@@ -32,7 +32,7 @@ TabBar.renderer = function (self)
                      | ImGui.TabBarFlags_FittingPolicyScroll()
                      | ImGui.TabBarFlags_NoTabListScrollingButtons()
 
-  if ImGui.BeginTabBar(ctx, 'TabBar', tabbar_flags) then
+  if ImGui.BeginTabBar(Ctx(), 'TabBar', tabbar_flags) then
     local tabs = self.options.tabs
     local current_value = self:value()
 
@@ -41,7 +41,7 @@ TabBar.renderer = function (self)
     end
 
     for i, tab in ipairs(tabs) do
-      ImGui.PushID(ctx, 'tab- ' .. i)
+      ImGui.PushID(Ctx(), 'tab- ' .. i)
       Trap(function()
         if tab.on_click then
           TabBar.render_tab_button(self, tab)
@@ -49,9 +49,9 @@ TabBar.renderer = function (self)
           TabBar.render_tab_item(self, tab, current_value)
         end
       end)
-      ImGui.PopID(ctx)
+      ImGui.PopID(Ctx())
     end
-    ImGui.EndTabBar(ctx)
+    ImGui.EndTabBar(Ctx())
   end
 end
 
@@ -63,7 +63,7 @@ TabBar.tab = function(key, label)
 end
 
 TabBar.render_tab_button = function(self, tab)
-  if ImGui.TabItemButton(ctx, tab.label, TabBar.tab_flags(tab)) then
+  if ImGui.TabItemButton(Ctx(), tab.label, TabBar.tab_flags(tab)) then
     tab.on_click()
   end
   tab.render()
@@ -96,7 +96,7 @@ TabBar.render_tab_item = function(self, tab, current_value)
     flags = flags | ImGui.TabItemFlags_NoAssumedClosure()
   end
 
-  local tab_selected, tab_open = ImGui.BeginTabItem(ctx, label, closeable, flags)
+  local tab_selected, tab_open = ImGui.BeginTabItem(Ctx(), label, closeable, flags)
 
   Trap(function()
     if (closeable and not tab_open) and tab.will_close() then
@@ -110,7 +110,7 @@ TabBar.render_tab_item = function(self, tab, current_value)
         self:set(tab.key)
       end
     end)
-    ImGui.EndTabItem(ctx)
+    ImGui.EndTabItem(Ctx())
   end
 end
 

--- a/reascripts/ReaSpeech/source/ui/widgets/TextInput.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/TextInput.lua
@@ -47,10 +47,10 @@ TextInput.renderer = function (self)
 
   local imgui_label = ("##%s"):format(options.label)
 
-  local rv, value = ImGui.InputText(ctx, imgui_label, self:value())
+  local rv, value = ImGui.InputText(Ctx(), imgui_label, self:value())
 
-  if ImGui.IsItemDeactivated(ctx) then
-    if ImGui.IsKeyPressed(ctx, ImGui.Key_Escape()) then
+  if ImGui.IsItemDeactivated(Ctx()) then
+    if ImGui.IsKeyPressed(Ctx(), ImGui.Key_Escape()) then
       self.options.on_cancel()
     else
       self.options.on_enter()

--- a/reascripts/ReaSpeech/tests/TestWidgets.lua
+++ b/reascripts/ReaSpeech/tests/TestWidgets.lua
@@ -6,6 +6,7 @@ require('tests/mock_reaper')
 
 require('include/globals')
 
+require('libs/Ctx')
 require('libs/Trap')
 require('ui/Widgets')
 

--- a/reascripts/ReaSpeech/tests/libs/TestToolWindow.lua
+++ b/reascripts/ReaSpeech/tests/libs/TestToolWindow.lua
@@ -6,6 +6,7 @@ require('tests/mock_reaper')
 
 require('include/globals')
 
+require('libs/Ctx')
 require('libs/ImGuiTheme')
 require('libs/Logging')
 require('libs/Polo')
@@ -216,6 +217,7 @@ function TestToolWindow:testRender()
   ImGui.SetNextWindowFocus = function(_) end
   ImGui.SetNextWindowPos = function(_, _, _, _, _, _) end
   ImGui.SetNextWindowSize = function(_, _, _, _) end
+  ImGui.ValidatePtr = function(_, _) return true end
   ImGui.Viewport_GetCenter = function() return 0, 0 end
   ImGui.WindowFlags_AlwaysAutoResize = function() return 0 end
   ImGui.WindowFlags_NoCollapse = function() return 1 end

--- a/reascripts/ReaSpeech/tests/mock_reaper.lua
+++ b/reascripts/ReaSpeech/tests/mock_reaper.lua
@@ -97,6 +97,8 @@ reaper = reaper or {
   ShowConsoleMsg = print,
   ShowMessageBox = print,
 
+  ImGui_ValidatePtr = function (_pointer, _ctypename) return true end,
+
   ImGui_PushStyleColor = function (_context, _key, _value) end,
   ImGui_PopStyleColor = function (_context, _count) end,
 


### PR DESCRIPTION
I'm seeing lots of "expected a valid ImGui_Context" errors on Mac, not just at startup but during transcription. They crash the app. We previously made a change to introduce a `Ctx()` helper that automatically recreates the ImGui context whenever it becomes invalid, but we did not use it throughout the codebase because of performance concerns. However, given the current behavior, I think it's best to use this helper everywhere, even if it introduces some slowdown, because the alternative means crashes and data loss.

I think one possible reason this is happening during transcription is that we are making blocking curl calls to check for transcription status, and this increases the likelihood that the ImGui context will be garbage collected due to delays between frame rendering. I'm not sure when or why this has gotten worse, but the problem is much more severe now than it has been in the past.

As part of this change, the `ctx` global variable is removed. The context is still available at `Ctx.ctx` for debugging purposes.