### PR TITLE
New release workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,3 +45,14 @@ jobs:
         DOCKER_IMAGE_LATEST=$REPO_NAME:latest${{ matrix.tag_extension }}
         DOCKER_IMAGE_VERSION=$REPO_NAME:$GITHUB_REF_NAME${{ matrix.tag_extension }}
         docker buildx build . --no-cache --platform=${{ matrix.platforms }} -t "${DOCKER_IMAGE_LATEST}" -t "${DOCKER_IMAGE_VERSION}" -f ${{ matrix.docker_file }} --push
+
+  release: 
+    if: contains(github.ref, 'tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Publish GitHub Release Notes to website repo
+
+on:
+  release:
+    types: [edited]
+  workflow_dispatch: 
+    inputs:
+      project_id:
+        description: 'Project ID'
+        required: true
+        default: 'Test Project'
+      project_name:
+        description: 'Test project name'
+        required: true
+        default: 'Test Project Name'
+      project_repository:
+        description: 'GitHub repository where the project is hosted'
+        required: true
+        default: 'Test Repo'
+      release_body:
+        description: 'Release body content'
+        required: true
+        default: 'Release body content goes here'
+
+jobs:
+  publish-release-notes:
+    runs-on: ubuntu-latest
+    # if: ${{ github.event.release.prerelease == false }} 
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: TeamAudio/techaudio-web
+          ref: actions-v1
+          fetch-depth: 0  # Fetch all history for accurate versioning
+          token: ${{ secrets.PUBLISH_RELEASE_SERVICE_TOKEN}}
+          path: techaudio-web
+
+      - name: Call publish-release action
+        uses: ./techaudio-web/.github/actions/publish-release
+        with:
+          project_id: reaspeech
+          project_name: ReaSpeech
+          project_repository: ${{ github.repository }}
+          version_tag: ${{ github.event.release.tag_name || 'v0.0.1-test' }}
+          release_body: ${{ github.event.release.body }}
+          service_token: ${{ secrets.PUBLISH_RELEASE_SERVICE_TOKEN }}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -102,9 +102,13 @@ def run_command(command, description):
         print("DRY RUN: Command not executed.")
         return True
     try:
-        result = subprocess.run(command, shell=True, check=True,
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                               universal_newlines=True)
+        result = subprocess.run(command, 
+                               shell=True, 
+                               check=True,
+                               stdout=subprocess.PIPE, 
+                               stderr=subprocess.PIPE,
+                               universal_newlines=True)  
+        
         print(f"{description}: Success")
         if result.stdout:
             print(result.stdout)
@@ -152,21 +156,21 @@ def main():
     tag = f"v{version}"
 
     # Stage version.lua and commit
-    if not run_command(f"git add {VERSION_FILE}", "Staging version.lua"):
+    if not run_command(["git", "add", f"{VERSION_FILE}"], "Staging version.lua"):
         sys.exit(1)
 
-    if not run_command(f"git commit -m 'Release {tag}'", "Committing changes"):
+    if not run_command(["git", "commit", "-m", f"Release {tag}"], "Committing changes"):
         sys.exit(1)
 
     # Create tag
-    if not run_command(f"git tag {tag}", f"Creating tag {tag}"):
+    if not run_command(["git", "tag", tag], f"Creating tag {tag}"):
         sys.exit(1)
 
     # Push to origin
-    if not run_command("git push origin main", "Pushing to main branch"):
+    if not run_command(["git", "push", "origin", "main"], "Pushing to main branch"):
         sys.exit(1)
 
-    if not run_command(f"git push origin {tag}", f"Pushing tag {tag}"):
+    if not run_command(["git", "push", "origin", tag], f"Pushing tag {tag}"):
         sys.exit(1)
 
     print(f"\nRelease {version} completed successfully!")


### PR DESCRIPTION
I added logic to create a new release (set as a pre-release) upon successful build and publication of the Docker image job, if the associated tag is versioned using the `softprops/action-gh-release@v2` action used in the rslite `build_and_test.yml`.  Similarly to rslite, once the pre-release status is removed, and it becomes an official release, it will trigger the release workflow resulting in updating the website with any release notes and, for major/minor releases, a blog post.  I also updated release.py to be able to run on Windows without erroring by passing the git commands as lists of strings instead of strings.  