### PR TITLE
Decode Unicode from pywhispercpp byte strings

### DIFF
--- a/app/whisper_cpp/model.py
+++ b/app/whisper_cpp/model.py
@@ -49,6 +49,11 @@ class Model(BaseModel):
             t0 = pw.whisper_full_get_segment_t0(ctx, i)
             t1 = pw.whisper_full_get_segment_t1(ctx, i)
             text = pw.whisper_full_get_segment_text(ctx, i)
+
+            # Ensure text is a string, not bytes
+            if isinstance(text, bytes):
+                text = text.decode('utf-8', errors='replace')
+
             token_n = pw.whisper_full_n_tokens(ctx, i)
             words = []
             for j in range(0, token_n):
@@ -57,6 +62,11 @@ class Model(BaseModel):
                 token_data = pw.whisper_full_get_token_data(ctx, i, j)
                 token_text = pw.whisper_full_get_token_text(ctx, i, j)
                 token_p = pw.whisper_full_get_token_p(ctx, i, j)
+
+                # Ensure token_text is a string, not bytes
+                if isinstance(token_text, bytes):
+                    token_text = token_text.decode('utf-8', errors='replace')
+
                 if words and not token_text.startswith(' '):
                     words[-1].t1 = token_data.t1
                     words[-1].text += token_text.strip()


### PR DESCRIPTION
Depending on the version of pywhispercpp, text returned by whisper.cpp can be byte strings instead of Unicode strings. This is resulting in errors like the following:

```
[2025-07-28 09:08:34,539] [celery.app.trace] [ERROR] Task transcribe[d6b0668e-dc31-47d3-9204-30ea3d0b167c] raised unexpected: TypeError('can only concatenate str (not "bytes") to str')
Traceback (most recent call last):
  File "/Users/dave/Source/reaspeech/.venv/lib/python3.10/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/Users/dave/Source/reaspeech/.venv/lib/python3.10/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "/Users/dave/Source/reaspeech/app/worker.py", line 93, in transcribe
    result = asr_engine.transcribe(audio_data, asr_options, output_format)
  File "/Users/dave/Source/reaspeech/app/whisper_cpp/core.py", line 87, in transcribe
    text = text + segment.text + " "
TypeError: can only concatenate str (not "bytes") to str
```

This change ensures that Word and Segment instances always contain Unicode strings.