### PR TITLE
Update fonts for ReaImGui 0.10 and require at least that version

### DIFF
--- a/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
+++ b/reascripts/ReaSpeech/source/main/ReaSpeechMain.lua
@@ -34,6 +34,24 @@ end
 
 function ReaSpeechMain:check_imgui()
   if ImGui.CreateContext then
+    local _, _, reaimgui_version_string = ImGui.GetVersion()
+
+    local major, minor = reaimgui_version_string:match("(%d+)%.(%d+)")
+    major = tonumber(major)
+    minor = tonumber(minor)
+
+    if major == 0 and minor < 10 then
+      reaper.MB(
+        "ReaSpeech requires ReaImGui version 0.10 or higher.\n\n"
+        .. "Please update ReaImGui from:\n\n"
+        .. "Extensions > ReaPack > Browse packages...",
+        "ReaImGui version error",
+        0
+      )
+      return false
+    end
+
+
     return true
   else
     reaper.MB(

--- a/reascripts/ReaSpeech/source/ui/ReaSpeechWelcomeUI.lua
+++ b/reascripts/ReaSpeech/source/ui/ReaSpeechWelcomeUI.lua
@@ -80,13 +80,11 @@ function ReaSpeechWelcomeUI:render_close_button()
 end
 
 function ReaSpeechWelcomeUI:render_heading(text)
-  ImGui.PushFont(Ctx(), Fonts.bold)
-  Trap(function ()
+  Fonts.wrap(Ctx(), Fonts.bold, function()
     ImGui.Dummy(Ctx(), self.WIDTH, self.HEADING_MARGIN)
     ImGui.SetCursorPosX(Ctx(), self.PADDING)
     ImGui.Text(Ctx(), text)
-  end)
-  ImGui.PopFont(Ctx())
+  end, Trap)
 end
 
 function ReaSpeechWelcomeUI:render_text(text)

--- a/reascripts/ReaSpeech/source/ui/SettingsControls.lua
+++ b/reascripts/ReaSpeech/source/ui/SettingsControls.lua
@@ -31,6 +31,8 @@ function SettingsControls:init()
   self.font_size = Widgets.NumberInput.new {
     state = Fonts.size,
     label = 'Font Size',
+    min = Fonts.MIN_SIZE,
+    max = Fonts.MAX_SIZE,
   }
 
   self:init_logging()

--- a/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptUI.lua
@@ -343,8 +343,7 @@ function TranscriptUI:render()
 end
 
 function TranscriptUI:render_name()
-  ImGui.PushFont(Ctx(), Fonts.big)
-  Trap(function()
+  Fonts.wrap(Ctx(), Fonts.big, function()
     if self.editing_name then
       self.name_editor:render()
     else
@@ -365,8 +364,7 @@ function TranscriptUI:render_name()
       end
       ImGui.Dummy(Ctx(), 1, 2)
     end
-  end)
-  ImGui.PopFont(Ctx())
+  end, Trap)
 end
 
 function TranscriptUI:render_result_actions()

--- a/reascripts/ReaSpeech/source/ui/widgets/NumberInput.lua
+++ b/reascripts/ReaSpeech/source/ui/widgets/NumberInput.lua
@@ -13,6 +13,8 @@ NumberInput.new = function (options)
     label = nil,
   }
   options.default = options.default or 0
+  options.min = options.min or nil
+  options.max = options.max or nil
 
   local o = ReaSpeechWidget.new({
     state = options.state,
@@ -39,9 +41,13 @@ NumberInput.renderer = function (self)
 
   local imgui_label = ("##%s"):format(options.label)
 
-  local rv, value = ImGui.InputInt(Ctx(), imgui_label, self:value())
+  local current_value = self:value()
 
-  if rv and ImGui.IsItemDeactivatedAfterEdit(Ctx()) then
+  local rv, value = ImGui.InputInt(Ctx(), imgui_label, current_value)
+
+  local in_bounds = (options.min == nil or value >= options.min) and (options.max == nil or value <= options.max)
+
+  if rv and in_bounds then
     self:set(value)
   end
 end

--- a/reascripts/ReaSpeech/tests/TestFonts.lua
+++ b/reascripts/ReaSpeech/tests/TestFonts.lua
@@ -15,7 +15,7 @@ function TestFonts:testWrap()
 
   local push_called = false
   local pop_called = false
-  ImGui.PushFont = function(_, _font)
+  ImGui.PushFont = function(_, _font, _size)
     push_called = true
   end
   ImGui.PopFont = function(_)
@@ -38,12 +38,28 @@ function TestFonts:testWrap()
   reaper = old_reaper
 end
 
+function TestFonts:testFont()
+  local old_create_font = ImGui.CreateFont
+  ImGui.CreateFont = function(_, name, size)
+    -- object will be an actual font object in the real implementation
+    return { object = 'sans-serif', size = size }
+  end
+
+  local font = Fonts:create_font('sans-serif', 12)
+
+  lu.assertEquals(font.object, ImGui.CreateFont('sans-serif', 12))
+
+  lu.assertEquals(font.size, 12)
+
+  ImGui.CreateFont = old_create_font
+end
+
 function TestFonts:testWrapErrorHandler()
   local old_imgui = ImGui
 
   local push_called = false
   local pop_called = false
-  ImGui.PushFont = function(_, _font)
+  ImGui.PushFont = function(_, _font, _size)
     push_called = true
   end
   ImGui.PopFont = function()
@@ -75,7 +91,7 @@ function TestFonts:testErrorHandlerDefault()
   local old_reaper = reaper
 
   local push_called = false
-  ImGui.PushFont = function(_, _font)
+  ImGui.PushFont = function(_, _font, _size)
     push_called = true
   end
 

--- a/reascripts/ReaSpeech/tests/TestFonts.lua
+++ b/reascripts/ReaSpeech/tests/TestFonts.lua
@@ -38,7 +38,7 @@ function TestFonts:testWrap()
   reaper = old_reaper
 end
 
-function TestFonts:testFont()
+function TestFonts:testCreateFont()
   local old_create_font = ImGui.CreateFont
   ImGui.CreateFont = function(_, name, size)
     -- object will be an actual font object in the real implementation

--- a/reascripts/ReaSpeech/tests/mock_reaper.lua
+++ b/reascripts/ReaSpeech/tests/mock_reaper.lua
@@ -167,4 +167,5 @@ ImGui = ImGui or {
   WindowFlags_TopMost = function() return 4 end,
   Cond_FirstUseEver = function() return 0 end,
   Cond_Appearing = function() return 1 end,
+  FontFlags_None = function() return 0 end,
 }


### PR DESCRIPTION
We've been waiting for this ReaImGui update for a long time now! 🚀🚀🚀🚀🚀

Instead of just creating the font userdata objects, we're now storing a table of `{ object = <imgui font>, size = <font size> }` to pass along to `PushFont/PopFont`. Also, remaining usages of `PushFont/PopFont` have been replaced with `Fonts.wrap`.

I added a few bounds-related arguments/checks around the number input - it was acting a bit weird and unresponsive to clicks on the increment/decrement buttons. 🤔