### PR TITLE
change dockerhub link text in release notes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,5 +63,5 @@ jobs:
         with:
           prerelease: true
           generate_release_notes: true
-          body: "[Latest Release](${{ vars.LATEST_RELEASE_URL }})"
+          body: "Get the latest Docker image at [Docker Hub](${{ vars.LATEST_RELEASE_URL }})!"
           append_body: true


### PR DESCRIPTION
Change the test for the Docker Hub link in the release notes to make it look more better and more clearer.