### PR TITLE
Fix edit window due to ReaImGui 0.10 upgrade

### DIFF
--- a/reascripts/ReaSpeech/source/ui/TranscriptEditor.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptEditor.lua
@@ -119,7 +119,6 @@ function TranscriptEditor:render_word_navigation()
   local num_words = #words
   local spacing = ImGui.GetStyleVar(Ctx(), ImGui.StyleVar_ItemInnerSpacing())
 
-  ImGui.PushButtonRepeat(Ctx(), true)
   Trap(function ()
     if ImGui.ArrowButton(Ctx(), '##left', ImGui.Dir_Left()) then
       self:edit_word(self.editing.word_index - 1)
@@ -129,7 +128,6 @@ function TranscriptEditor:render_word_navigation()
       self:edit_word(self.editing.word_index + 1)
     end
   end)
-  ImGui.PopButtonRepeat(Ctx())
 
   ImGui.SameLine(Ctx())
   ImGui.AlignTextToFramePadding(Ctx())


### PR DESCRIPTION
The PushButtonRepeat/PopButtonRepeat functions were removed from ImGui. They enabled holding the mouse button down to quickly navigate through words. There's a way to get this functionality by handling various mouse events, but I'm not sure how important it is to keep that behavior. This fixes the edit window so that it displays again.