### PR TITLE
Fix/curl uploads for files w quotes or commas

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -19,13 +19,15 @@ COPY . /app
 WORKDIR /app
 
 RUN /usr/bin/python${PYTHON_VERSION} -m venv $POETRY_VENV \
-    && $POETRY_VENV/bin/pip install -U pip setuptools \
+    && $POETRY_VENV/bin/pip install -U pip \
     && $POETRY_VENV/bin/pip install poetry==2.0.1
 
 ENV PATH="${PATH}:${POETRY_VENV}/bin"
 
 RUN poetry config virtualenvs.in-project true
-RUN poetry install && rm -rf /app/.cache/pypoetry
+RUN $POETRY_VENV/bin/pip install wheel \
+    && $POETRY_VENV/bin/pip install --no-build-isolation --no-deps "openai-whisper==20240930" \
+    && poetry install && rm -rf /app/.cache/pypoetry
 
 RUN git clone https://github.com/absadiki/pywhispercpp \
     && cd pywhispercpp \

--- a/reascripts/ReaSpeech/source/libs/CurlRequest.lua
+++ b/reascripts/ReaSpeech/source/libs/CurlRequest.lua
@@ -304,18 +304,25 @@ function CurlRequest._init()
     local uploads = {}
 
     for key, path in pairs(self.file_uploads or {}) do
-      table.insert(uploads, { '-F', self._maybe_quote(key .. '=@"' .. path .. '"') })
+      table.insert(uploads, { self._curl_file_upload_syntax(key, path) })
     end
 
     return table.flatten(uploads)
   end
 
-  function API._maybe_quote(str)
-    if EnvUtil.is_windows() then
-      return str
-    else
-      return "'" .. str .. "'"
+  function API._curl_file_upload_syntax(keyname, filename)
+    local result = '-F' .. keyname .. '=@'
+
+    if filename:find("[,;]") then     -- curl -F key=@"file" syntax
+      filename =  "\"".. filename.. "\""
     end
+
+    if filename:find("[ '\"]") then   -- spaces or quotes
+      result = '`' .. result .. filename .. '`'
+    else
+      result = result .. filename
+    end
+    return ' ' .. result
   end
 
   function API:curl_timeout_argument()


### PR DESCRIPTION
This patch fixes curl errors while uploading files with names containing single quotes, commas, or semicolons.

- #183 requires a specific curl syntax (double-quotes around _only_ the filename (not the arg, key, or `@`-sign))
      e.g. `-F key=@"/path/to/filename,with,commas.txt"`  
- #186 is solved by surrounding the entire  `-F` string  in backticks, which is supported by `reaper.ExecProcess` as a third quoting option that can encapsulate both single and double quotes

Fixes #183
Fixes #186