### PR TITLE
Clip transcript segments to each item's visible take section

### DIFF
--- a/reascripts/ReaSpeech/source/main/Transcript.lua
+++ b/reascripts/ReaSpeech/source/main/Transcript.lua
@@ -203,15 +203,27 @@ function Transcript:to_json()
 end
 
 function Transcript.from_json(json_str)
-  local data = json.decode(json_str)
+  return Transcript.from_table(json.decode(json_str))
+end
 
+function Transcript.from_table(data)
   local t = Transcript.new {
     name = data.name or ''
   }
 
+  local items_by_guid = {}
+  for item in ReaIter.each_media_item() do
+    local guid = ReaUtil.get_item_info(item, 'GUID')
+    if guid then
+      items_by_guid[guid] = item
+    end
+  end
+
   for _, segment_data in pairs(data.segments) do
-    local segment = TranscriptSegment.from_table(segment_data)
-    t:add_segment(segment)
+    local segment = TranscriptSegment.from_table(segment_data, items_by_guid)
+    if segment then
+      t:add_segment(segment)
+    end
   end
   t:update()
   return t

--- a/reascripts/ReaSpeech/source/main/TranscriptSegment.lua
+++ b/reascripts/ReaSpeech/source/main/TranscriptSegment.lua
@@ -29,7 +29,44 @@ function TranscriptSegment:init()
   self.data['file'] = self:get_file()
 end
 
+-- The source-time window that a take's visible section covers within its
+-- media item, or nil when the window cannot be determined
+TranscriptSegment.take_source_window = function(item, take)
+  local length = reaper.GetMediaItemInfo_Value(item, 'D_LENGTH')
+
+  if not length or length <= 0 then
+    return nil
+  end
+
+  local start_offset = reaper.GetMediaItemTakeInfo_Value(take, 'D_STARTOFFS')
+  local playrate = reaper.GetMediaItemTakeInfo_Value(take, 'D_PLAYRATE')
+
+  if not playrate or playrate <= 0 then
+    playrate = 1.0
+  end
+
+  return start_offset, start_offset + length * playrate
+end
+
+-- Whether any part of [start_time, end_time) is within the take's visible
+-- section; true when the section cannot be determined
+TranscriptSegment.overlaps_take_section = function(item, take, start_time, end_time)
+  local window_start, window_end = TranscriptSegment.take_source_window(item, take)
+
+  if not window_start then
+    return true
+  end
+
+  return end_time > window_start and start_time < window_end
+end
+
 TranscriptSegment.from_whisper = function(segment, item, take)
+  -- a source file can appear in many items; each item should only receive
+  -- the segments its visible section can play
+  if not TranscriptSegment.overlaps_take_section(item, take, segment.start, segment['end']) then
+    return {}
+  end
+
   local result = {}
   local words = segment.words
 
@@ -65,38 +102,48 @@ TranscriptSegment.from_whisper = function(segment, item, take)
   return result
 end
 
-TranscriptSegment.from_table = function(data)
+-- Returns nil for segments that fall outside their item's visible section;
+-- items_by_guid is an optional prebuilt GUID lookup to avoid per-segment
+-- scans of the project's media items
+TranscriptSegment.from_table = function(data, items_by_guid)
   local segment_data = {}
-  local words = data.words
   local item, take
-  data.words = nil
-
-  if words then
-    local transcript_words = {}
-    for _, word in pairs(words) do
-      table.insert(transcript_words, TranscriptWord.from_table(word))
-    end
-    data.words = transcript_words
-  end
 
   for k, v in pairs(data) do
     if k == 'item' then
-      item = ReaUtil.get_item_by_guid(v) or {}
+      if items_by_guid then
+        item = items_by_guid[v]
+      else
+        item = ReaUtil.get_item_by_guid(v)
+      end
     elseif k == 'take' then
-      take = reaper.GetMediaItemTakeByGUID(0, v) or {}
-    --luacheck: ignore
-    elseif k == 'words' then
-      -- empty branch is okay! already handled
-    else
+      take = reaper.GetMediaItemTakeByGUID(0, v)
+    elseif k ~= 'words' then
       segment_data[k] = v
+    end
+  end
+
+  -- transcripts saved before segments were clipped to their items can repeat
+  -- the full segment list once per item sharing the source file; drop the
+  -- copies that fall outside their item's visible section
+  if item and take and segment_data.start and segment_data['end']
+  and not TranscriptSegment.overlaps_take_section(item, take, segment_data.start, segment_data['end']) then
+    return nil
+  end
+
+  local transcript_words
+  if data.words then
+    transcript_words = {}
+    for _, word in pairs(data.words) do
+      table.insert(transcript_words, TranscriptWord.from_table(word))
     end
   end
 
   return TranscriptSegment.new {
     data = segment_data,
-    item = item,
-    take = take,
-    words = data.words
+    item = item or {},
+    take = take or {},
+    words = transcript_words
   }
 end
 

--- a/reascripts/ReaSpeech/source/ui/TranscriptAnnotations.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptAnnotations.lua
@@ -13,38 +13,92 @@ function TranscriptAnnotations:init()
 end
 
 function TranscriptAnnotations:take_markers(use_words, track_filter_config)
-    track_filter_config = track_filter_config or { mode = 'ignore', tracks = {} }
+  track_filter_config = track_filter_config or { mode = 'ignore', tracks = {} }
 
-    local oddly_specific_black = 0x01030405
+  local oddly_specific_black = 0x01030405
 
-    local takes = {}
+  local source_paths = {}
+  local targets_by_path = {}
+  local stamped = {}
 
-    for element in self.transcript:iterator(use_words) do
-      local _, take_guid = reaper.GetSetMediaItemTakeInfo_String(element.take, 'GUID', '', false)
+  for element in self.transcript:iterator(use_words) do
+    local path = source_paths[element.take]
 
-      if not takes[take_guid] then
-        takes[take_guid] = {}
-        local path = ReaUtil.get_source_path(element.take)
+    if path == nil then
+      -- a transcript reloaded in a changed project can hold takes that no
+      -- longer exist; skip their elements instead of erroring out
+      local ok, result = Trap(function ()
+        return ReaUtil.get_source_path(element.take)
+      end)
+      path = ok and result or false
+      source_paths[element.take] = path
+    end
 
-        for item in ReaIter.each_media_item() do
-          for take in ReaIter.each_take(item) do
-            local take_path = ReaUtil.get_source_path(take)
+    if path and element.text then
+      if not targets_by_path[path] then
+        targets_by_path[path] = self:_take_marker_targets(path, track_filter_config)
+      end
 
-            if take_path == path then
-              local track_guid = reaper.GetTrackGUID(reaper.GetMediaItemTake_Track(take))
-              if track_filter_config.mode == 'ignore' and not track_filter_config.tracks[track_guid]
-              or track_filter_config.mode == 'include' and track_filter_config.tracks[track_guid] then
-                table.insert(takes[take_guid], take)
-              end
-            end
+      for _, target in ipairs(targets_by_path[path]) do
+        if not target.window_start
+        or (element.start >= target.window_start and element.start < target.window_end) then
+          if not stamped[target.take] then
+            stamped[target.take] = self._existing_take_markers(target.take)
+          end
+
+          local marker_key = element.start .. '\0' .. element.text
+          if not stamped[target.take][marker_key] then
+            stamped[target.take][marker_key] = true
+            reaper.SetTakeMarker(target.take, -1, element.text, element.start, oddly_specific_black)
           end
         end
       end
+    end
+  end
+end
 
-      for _, take in ipairs(takes[take_guid]) do
-        reaper.SetTakeMarker(take, -1, element.text, element.start, oddly_specific_black)
+function TranscriptAnnotations:_take_marker_targets(path, track_filter_config)
+  local targets = {}
+
+  for item in ReaIter.each_media_item() do
+    for take in ReaIter.each_take(item) do
+      if ReaUtil.get_source_path(take) == path
+      and self._track_filter_allows(track_filter_config, take) then
+        local window_start, window_end = TranscriptSegment.take_source_window(item, take)
+
+        table.insert(targets, {
+          take = take,
+          window_start = window_start,
+          window_end = window_end
+        })
       end
     end
+  end
+
+  return targets
+end
+
+function TranscriptAnnotations._track_filter_allows(track_filter_config, take)
+  local track_guid = reaper.GetTrackGUID(reaper.GetMediaItemTake_Track(take))
+
+  if track_filter_config.mode == 'ignore' then
+    return not track_filter_config.tracks[track_guid]
+  elseif track_filter_config.mode == 'include' then
+    return track_filter_config.tracks[track_guid] and true or false
+  end
+
+  return false
+end
+
+function TranscriptAnnotations._existing_take_markers(take)
+  local existing = {}
+
+  for i = 0, reaper.GetNumTakeMarkers(take) - 1 do
+    local position, name = reaper.GetTakeMarker(take, i)
+    existing[position .. '\0' .. name] = true
+  end
+
+  return existing
 end
 
 function TranscriptAnnotations:project_markers(project, use_words)

--- a/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
@@ -141,7 +141,7 @@ function TranscriptImporter:import(filepath)
     return nil, 'Invalid JSON'
   end
 
-  if not parsed.segments then
+  if type(parsed.segments) ~= 'table' then
     return nil, 'No segments field'
   end
 

--- a/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
+++ b/reascripts/ReaSpeech/source/ui/TranscriptImporter.lua
@@ -118,6 +118,10 @@ function TranscriptImporter:can_import(filepath)
 end
 
 function TranscriptImporter:import(filepath)
+  if not PathUtil.has_extension(filepath, 'json') then
+    return nil, 'File must be a JSON file'
+  end
+
   local file = io.open(filepath, 'r')
   if not file then
     return nil, 'File not found'
@@ -126,9 +130,22 @@ function TranscriptImporter:import(filepath)
   local content = file:read('*a')
   file:close()
 
-  local transcript = Transcript.from_json(content)
+  if not content or #content < 1 then
+    return nil, 'File is empty'
+  end
 
-  return transcript
+  local parsed
+  if not Trap(function ()
+    parsed = json.decode(content)
+  end) or type(parsed) ~= 'table' then
+    return nil, 'Invalid JSON'
+  end
+
+  if not parsed.segments then
+    return nil, 'No segments field'
+  end
+
+  return Transcript.from_table(parsed)
 end
 
 function TranscriptImporter:quick_import()
@@ -155,23 +172,17 @@ function TranscriptImporter:quick_import()
     local load_errors = {}
 
     for _, filename in ipairs(valid_filenames) do
-      local can_import, msg = self:can_import(filename)
+      local transcript, err = self:import(filename)
 
-      if not can_import then
-        table.insert(load_errors, {filename, msg})
+      if not transcript or err then
+        table.insert(load_errors, {filename, err})
       else
-        local transcript, err = self:import(filename)
-
-        if not transcript or err then
-          table.insert(load_errors, {filename, err})
-        else
-          local plugin = TranscriptUI.new {
-            app = app,
-            transcript = transcript,
-            _transcript_saved = true
-          }
-          app.plugins:add_plugin(plugin)
-        end
+        local plugin = TranscriptUI.new {
+          app = app,
+          transcript = transcript,
+          _transcript_saved = true
+        }
+        app.plugins:add_plugin(plugin)
       end
     end
 

--- a/reascripts/ReaSpeech/tests/TestTranscript.lua
+++ b/reascripts/ReaSpeech/tests/TestTranscript.lua
@@ -568,6 +568,207 @@ function TestTranscript:TestFromJson()
   lu.assertEquals(t.init_data[2].take, "take_userdata2")
 end
 
+function TestTranscript:testFromJsonClipsLegacySegments()
+  -- two items splitting one source file: item 1 shows source [0, 2),
+  -- item 2 shows source [2, 4)
+  reaper.CountMediaItems = function() return 2 end
+  reaper.GetMediaItem = function(_, idx)
+    if idx == 0 then
+      return "split_item_1"
+    elseif idx == 1 then
+      return "split_item_2"
+    end
+  end
+
+  ReaIter.each_media_item = ReaIter._make_iterator(reaper.CountMediaItems, reaper.GetMediaItem)
+
+  reaper.GetMediaItemTakeByGUID = function(_, guid)
+    return ({
+      split_take_guid1 = "split_take_1",
+      split_take_guid2 = "split_take_2",
+    })[guid]
+  end
+
+  local fake_guids = {
+    split_item_1 = "split_item_guid1",
+    split_item_2 = "split_item_guid2",
+  }
+
+  reaper.GetSetMediaItemInfo_String = function(item, param)
+    if param == 'GUID' then
+      return true, fake_guids[item]
+    end
+  end
+
+  reaper.GetMediaItemInfo_Value = function (item, param)
+    if param == 'D_LENGTH' then
+      return ({ split_item_1 = 2.0, split_item_2 = 2.0 })[item] or 0
+    end
+    return 0
+  end
+
+  reaper.GetMediaItemTakeInfo_Value = function (take, param)
+    if param == 'D_STARTOFFS' then
+      return ({ split_take_1 = 0.0, split_take_2 = 2.0 })[take] or 0
+    elseif param == 'D_PLAYRATE' then
+      return 1.0
+    end
+    return 0
+  end
+
+  -- transcripts saved before segments were clipped to their items repeat
+  -- the full segment list once per item sharing the source file
+  local segments = {}
+  for _, guids in ipairs({
+    { item = "split_item_guid1", take = "split_take_guid1" },
+    { item = "split_item_guid2", take = "split_take_guid2" },
+  }) do
+    table.insert(segments, {
+      id = 1, start = 0.5, ['end'] = 1.5, text = "test 1",
+      item = guids.item, take = guids.take
+    })
+    table.insert(segments, {
+      id = 2, start = 2.5, ['end'] = 3.5, text = "test 2",
+      item = guids.item, take = guids.take
+    })
+  end
+
+  local t = Transcript.from_json(json.encode({ name = "test", segments = segments }))
+
+  lu.assertEquals(#t.init_data, 2)
+  lu.assertEquals(t.init_data[1].data.text, "test 1")
+  lu.assertEquals(t.init_data[1].take, "split_take_1")
+  lu.assertEquals(t.init_data[2].data.text, "test 2")
+  lu.assertEquals(t.init_data[2].take, "split_take_2")
+end
+
+function TestTranscript:testFromJsonKeepsUnresolvableSegments()
+  -- importing into a different project: no GUIDs resolve, nothing is clipped
+  reaper.CountMediaItems = function() return 0 end
+  ReaIter.each_media_item = ReaIter._make_iterator(reaper.CountMediaItems, reaper.GetMediaItem)
+  reaper.GetMediaItemTakeByGUID = function(_, _) return nil end
+
+  local segments = {
+    {
+      id = 1, start = 0.5, ['end'] = 1.5, text = "test 1",
+      item = "unknown_item_guid", take = "unknown_take_guid"
+    },
+    {
+      id = 2, start = 2.5, ['end'] = 3.5, text = "test 2",
+      item = "unknown_item_guid", take = "unknown_take_guid"
+    },
+  }
+
+  local t = Transcript.from_json(json.encode({ name = "test", segments = segments }))
+
+  lu.assertEquals(#t.init_data, 2)
+  lu.assertEquals(t.init_data[1].item, {})
+  lu.assertEquals(t.init_data[1].take, {})
+end
+
+TestFromWhisper = {
+  -- source-time window per item/take, applied by the mocks below
+  item_lengths = {},
+  take_offsets = {},
+  take_playrates = {},
+
+  whisper_segment = function (overrides)
+    local segment = {
+      id = 1,
+      start = 1.0,
+      ['end'] = 2.0,
+      text = "test 1",
+      words = {
+        { word = "test", start = 1.0, ['end'] = 1.5, probability = 1.0 },
+        { word = "1", start = 1.5, ['end'] = 2.0, probability = 0.5 }
+      }
+    }
+    for k, v in pairs(overrides or {}) do
+      segment[k] = v
+    end
+    return segment
+  end
+}
+
+function TestFromWhisper:setUp()
+  reaper.__test_setUp()
+
+  TestFromWhisper.item_lengths = {}
+  TestFromWhisper.take_offsets = {}
+  TestFromWhisper.take_playrates = {}
+
+  reaper.GetMediaItemInfo_Value = function (item, param)
+    if param == 'D_LENGTH' then
+      return TestFromWhisper.item_lengths[item] or 0
+    end
+    return 0
+  end
+
+  reaper.GetMediaItemTakeInfo_Value = function (take, param)
+    if param == 'D_STARTOFFS' then
+      return TestFromWhisper.take_offsets[take] or 0
+    elseif param == 'D_PLAYRATE' then
+      return TestFromWhisper.take_playrates[take] or 1.0
+    end
+    return 0
+  end
+end
+
+function TestFromWhisper:testKeepsSegmentInsideTakeSection()
+  TestFromWhisper.item_lengths['item'] = 2.0
+  TestFromWhisper.take_offsets['take'] = 0.5
+
+  local segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 1)
+  lu.assertEquals(segments[1]:get('text'), "test 1")
+end
+
+function TestFromWhisper:testDropsSegmentOutsideTakeSection()
+  TestFromWhisper.item_lengths['item'] = 2.0
+  TestFromWhisper.take_offsets['take'] = 10.0
+
+  local segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 0)
+
+  -- ends exactly at the start of the section
+  TestFromWhisper.take_offsets['take'] = 2.0
+  segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 0)
+
+  -- starts exactly at the end of the section
+  TestFromWhisper.take_offsets['take'] = 0.0
+  TestFromWhisper.item_lengths['item'] = 1.0
+  segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 0)
+end
+
+function TestFromWhisper:testKeepsSegmentStraddlingTakeSection()
+  TestFromWhisper.item_lengths['item'] = 2.0
+  TestFromWhisper.take_offsets['take'] = 1.5
+
+  local segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 1)
+end
+
+function TestFromWhisper:testHonorsPlayrate()
+  -- section covers source time [0.0, 0.5) at playrate 1.0; [0.0, 2.0) at 4.0
+  TestFromWhisper.item_lengths['item'] = 0.5
+  TestFromWhisper.take_offsets['take'] = 0.0
+
+  local segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 0)
+
+  TestFromWhisper.take_playrates['take'] = 4.0
+  segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 1)
+end
+
+function TestFromWhisper:testKeepsSegmentWhenSectionUnknown()
+  -- no item length available: no window to clip against
+  local segments = TranscriptSegment.from_whisper(self.whisper_segment(), 'item', 'take')
+  lu.assertEquals(#segments, 1)
+end
+
 --
 
 os.exit(lu.LuaUnit.run())

--- a/reascripts/ReaSpeech/tests/TestTranscriptAnnotations.lua
+++ b/reascripts/ReaSpeech/tests/TestTranscriptAnnotations.lua
@@ -65,6 +65,16 @@ reaper.SetTakeMarker = function(take, _index, name, pos, color)
   })
 end
 
+reaper.GetNumTakeMarkers = function(take)
+  local markers = reaper_state.take_markers[take]
+  return markers and #markers or 0
+end
+
+reaper.GetTakeMarker = function(take, idx)
+  local marker = reaper_state.take_markers[take][idx + 1]
+  return marker.pos, marker.name, marker.color
+end
+
 reaper.GetCursorPosition = function () return 0 end
 reaper.GetMediaItemInfo_Value = function (_, _) return 0 end
 reaper.GetMediaItemTakeInfo_Value = function (_, _) return 0 end
@@ -123,12 +133,87 @@ TestTranscriptMarkers = {
   word = TranscriptWord.new
 }
 
+local original_get_source_path = ReaUtil.get_source_path
+
 function TestTranscriptMarkers:setUp()
   reaper_state = {
     markers = {},
     item_state_chunk = "",
     take_markers = {},
   }
+
+  ReaUtil.get_source_path = original_get_source_path
+  reaper.GetMediaItemInfo_Value = function (_, _) return 0 end
+  reaper.GetMediaItemTakeInfo_Value = function (_, _) return 0 end
+end
+
+-- One source file split into three items, each showing a two-second slice:
+-- take 1 covers source time [0, 2), take 2 covers [2, 4), take 3 covers [4, 6)
+function TestTranscriptMarkers:setup_split_project()
+  reaper.GetSetMediaItemTakeInfo_String = function(take, _)
+    return true, ({
+      ['take 1'] = "take 1 guid",
+      ['take 2'] = "take 2 guid",
+      ['take 3'] = "take 3 guid",
+    })[take]
+  end
+
+  reaper.CountMediaItems = function () return 3 end
+
+  reaper.GetMediaItem = function (_, i)
+    return ({
+      [0] = "item 1",
+      [1] = "item 2",
+      [2] = "item 3",
+    })[i]
+  end
+
+  reaper.CountTakes = function (_) return 1 end
+
+  reaper.GetTake = function (item, _)
+    return ({
+      ["item 1"] = "take 1",
+      ["item 2"] = "take 2",
+      ["item 3"] = "take 3",
+    })[item]
+  end
+
+  ReaIter.each_media_item = ReaIter._make_iterator(reaper.CountMediaItems, reaper.GetMediaItem)
+  ReaIter.each_take = ReaIter._make_iterator(reaper.CountTakes, reaper.GetTake)
+
+  reaper.GetMediaItemTake_Track = function (_) return "first track" end
+  reaper.GetTrackGUID = function (_) return "track 1 guid" end
+
+  ReaUtil.get_source_path = function (take)
+    if type(take) ~= 'string' then
+      error('invalid take')
+    end
+    return "interview.wav"
+  end
+
+  reaper.GetMediaItemInfo_Value = function (item, param)
+    if param == 'D_LENGTH' then
+      return ({
+        ['item 1'] = 2.0,
+        ['item 2'] = 2.0,
+        ['item 3'] = 2.0,
+      })[item] or 0
+    end
+    return 0
+  end
+
+  reaper.GetMediaItemTakeInfo_Value = function (take, param)
+    if param == 'D_STARTOFFS' then
+      return ({
+        ['take 1'] = 0.0,
+        ['take 2'] = 2.0,
+        ['take 3'] = 4.0,
+      })[take] or 0
+    elseif param == 'D_PLAYRATE' then
+      return 1.0
+    end
+    return 0
+  end
 end
 
 function TestTranscriptMarkers:testProjectMarkers()
@@ -352,6 +437,128 @@ function TestTranscriptMarkers:testTakeMarkersWords()
   lu.assertEquals(markers[4].name, "2%")
   lu.assertEquals(markers[4].pos, 2.5)
   lu.assertEquals(markers[4].color, 0x01030405)
+end
+
+function TestTranscriptMarkers:testTakeMarkersClippedToSplitItems()
+  self:setup_split_project()
+
+  local t = Transcript.new()
+  t:add_segment(self.segment {
+    id = 1,
+    start = 1.0,
+    end_ = 2.0,
+    text = "test 1",
+    take = 'take 1'
+  })
+  t:add_segment(self.segment {
+    id = 2,
+    start = 3.0,
+    end_ = 4.0,
+    text = "test 2",
+    take = 'take 2'
+  })
+  t:update()
+
+  local m = TranscriptAnnotations.new { transcript = t }
+  m:take_markers(false)
+
+  lu.assertEquals(#reaper_state.take_markers['take 1'], 1)
+  lu.assertEquals(reaper_state.take_markers['take 1'][1].name, "test 1")
+  lu.assertEquals(reaper_state.take_markers['take 1'][1].pos, 1.0)
+  lu.assertEquals(#reaper_state.take_markers['take 2'], 1)
+  lu.assertEquals(reaper_state.take_markers['take 2'][1].name, "test 2")
+  lu.assertEquals(reaper_state.take_markers['take 2'][1].pos, 3.0)
+  lu.assertIsNil(reaper_state.take_markers['take 3'])
+end
+
+function TestTranscriptMarkers:testTakeMarkersDeduplicatesLegacyTranscript()
+  self:setup_split_project()
+
+  -- transcripts saved before segments were clipped to their items repeat
+  -- the full segment list once per item sharing the source file
+  local t = Transcript.new()
+  for _, take in ipairs({'take 1', 'take 2', 'take 3'}) do
+    t:add_segment(self.segment {
+      id = 1,
+      start = 1.0,
+      end_ = 2.0,
+      text = "test 1",
+      take = take
+    })
+    t:add_segment(self.segment {
+      id = 2,
+      start = 3.0,
+      end_ = 4.0,
+      text = "test 2",
+      take = take
+    })
+  end
+  t:update()
+
+  local m = TranscriptAnnotations.new { transcript = t }
+  m:take_markers(false)
+
+  lu.assertEquals(#reaper_state.take_markers['take 1'], 1)
+  lu.assertEquals(reaper_state.take_markers['take 1'][1].name, "test 1")
+  lu.assertEquals(#reaper_state.take_markers['take 2'], 1)
+  lu.assertEquals(reaper_state.take_markers['take 2'][1].name, "test 2")
+  lu.assertIsNil(reaper_state.take_markers['take 3'])
+end
+
+function TestTranscriptMarkers:testTakeMarkersRerunIsIdempotent()
+  self:setup_split_project()
+
+  local t = Transcript.new()
+  t:add_segment(self.segment {
+    id = 1,
+    start = 1.0,
+    end_ = 2.0,
+    text = "test 1",
+    take = 'take 1'
+  })
+  t:update()
+
+  local m = TranscriptAnnotations.new { transcript = t }
+  m:take_markers(false)
+  m:take_markers(false)
+
+  lu.assertEquals(#reaper_state.take_markers['take 1'], 1)
+end
+
+function TestTranscriptMarkers:testTakeMarkersSkipsUnresolvableTake()
+  self:setup_split_project()
+
+  local trap_errors = 0
+  local original_on_error = Trap.on_error
+  Trap.on_error = function (_) trap_errors = trap_errors + 1 end
+
+  -- a transcript reloaded from JSON in a changed project can hold takes
+  -- whose GUIDs no longer resolve
+  local t = Transcript.new()
+  t:add_segment(self.segment {
+    id = 1,
+    start = 1.0,
+    end_ = 2.0,
+    text = "test 1",
+    take = {}
+  })
+  t:add_segment(self.segment {
+    id = 2,
+    start = 3.0,
+    end_ = 4.0,
+    text = "test 2",
+    take = 'take 2'
+  })
+  t:update()
+
+  local m = TranscriptAnnotations.new { transcript = t }
+  m:take_markers(false)
+
+  Trap.on_error = original_on_error
+
+  lu.assertEquals(#reaper_state.take_markers['take 2'], 1)
+  lu.assertIsNil(reaper_state.take_markers['take 1'])
+  lu.assertEquals(trap_errors, 1)
 end
 
 function TestTranscriptMarkers:testTakeMarkersTrackFilterInclude()


### PR DESCRIPTION
when one source file is referenced by many items (like a recording chopped into hundreds of slices), transcription fanned the full segment list out to every item sharing that source, and marker export stamped every element onto every matching take. in the blocking case that inspired this debugging (a VO session), hundreds of transcript segments exported ~170k take markers. yikes

this targets transcription, transcript import & marker export to limit based on a visibility window relative to the linked source files under a track/item/take.